### PR TITLE
Revert security cherry pick

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -228,7 +228,7 @@ deps = {
     'condition': 'checkout_android',
   },
   'src/third_party/usrsctp/usrsctplib':
-    'https://chromium.googlesource.com/external/github.com/sctplab/usrsctp@a8c51df76caae94254b1e59999405f739467490e',
+    'https://chromium.googlesource.com/external/github.com/sctplab/usrsctp@a68325e7d9ed844cc84ec134192d788586ea6cc1',
   # Dependency used by libjpeg-turbo.
   'src/third_party/yasm/binaries': {
     'url': 'https://chromium.googlesource.com/chromium/deps/yasm/binaries.git@52f9b3f4b0aa06da24ef8b123058bb61ee468881',


### PR DESCRIPTION
Reverting the usrsctp dependency since it now requires a iOS 10.1 target.