### PR TITLE
Fix mac build target

### DIFF
--- a/.gn
+++ b/.gn
@@ -60,9 +60,9 @@ default_args = {
   # component builds.
   is_component_build = false
 
-  mac_sdk_min = "10.12"
+  mac_sdk_min = "10.12.1"
 
-  ios_deployment_target = "10.0"
+  ios_deployment_target = "11.0"
 
   # The SDK API level, in contrast, is set by build/android/AndroidManifest.xml.
   android32_ndk_api_level = 16

--- a/modules/audio_device/BUILD.gn
+++ b/modules/audio_device/BUILD.gn
@@ -289,6 +289,8 @@ rtc_library("audio_device_impl") {
         }
       }
       if (is_mac) {
+        # Don't warn about deprecated OSAtomicCompareAndSwap32Barrier().
+        cflags += [ "-Wno-deprecated-declarations" ]
         sources += [
           "mac/audio_device_mac.cc",
           "mac/audio_device_mac.h",

--- a/modules/third_party/portaudio/BUILD.gn
+++ b/modules/third_party/portaudio/BUILD.gn
@@ -10,6 +10,8 @@ import("../../../webrtc.gni")
 
 rtc_library("mac_portaudio") {
   visibility = [ "../../audio_device:*" ]
+  # Don't warn about deprecated OSMemoryBarrier().
+  cflags = [ "-Wno-deprecated-declarations" ]
   sources = [
     "pa_memorybarrier.h",
     "pa_ringbuffer.c",


### PR DESCRIPTION
Increase the minimum Mac SDK to build SCTP library. Ignore warnings for some deprecated functions that appear.