### PR TITLE
Reapply the RingRTC observer changes

### DIFF
--- a/sdk/objc/api/peerconnection/RTCPeerConnection+Private.h
+++ b/sdk/objc/api/peerconnection/RTCPeerConnection+Private.h
@@ -80,8 +80,18 @@ class PeerConnectionDelegateAdapter : public PeerConnectionObserver {
 - (instancetype)initWithFactory:(RTC_OBJC_TYPE(RTCPeerConnectionFactory) *)factory
                   configuration:(RTC_OBJC_TYPE(RTCConfiguration) *)configuration
                     constraints:(RTC_OBJC_TYPE(RTCMediaConstraints) *)constraints
-                       observer:(void *)observer
-        NS_DESIGNATED_INITIALIZER;
+                       observer:(void *)observer;
+
+/** Initialize an RTCPeerConnection with a configuration, constraints,
+ *  observer and PeerConnectionDependencies.
+ */
+- (instancetype)initWithDependencies:(RTC_OBJC_TYPE(RTCPeerConnectionFactory) *)factory
+                       configuration:(RTC_OBJC_TYPE(RTCConfiguration) *)configuration
+                         constraints:(RTC_OBJC_TYPE(RTCMediaConstraints) *)constraints
+                        dependencies:
+                            (std::unique_ptr<webrtc::PeerConnectionDependencies>)dependencies
+                            observer:(void *)observer
+    NS_DESIGNATED_INITIALIZER;
 
 + (webrtc::PeerConnectionInterface::SignalingState)nativeSignalingStateForState:
         (RTCSignalingState)state;

--- a/sdk/objc/api/peerconnection/RTCPeerConnectionFactory+Native.h
+++ b/sdk/objc/api/peerconnection/RTCPeerConnectionFactory+Native.h
@@ -90,14 +90,14 @@ NS_ASSUME_NONNULL_BEGIN
             decoderFactory:(nullable id<RTC_OBJC_TYPE(RTCVideoDecoderFactory)>)decoderFactory
      mediaTransportFactory:(std::unique_ptr<webrtc::MediaTransportFactory>)mediaTransportFactory;
 
-/** Initialize an RTCPeerConnection with a configuration, constraints, and
- *  dependencies.
+/** Initialize an RTCPeerConnection with a configuration, constraints, dependencies,
+ *  and observer.
  */
 - (RTC_OBJC_TYPE(RTCPeerConnection) *)
     peerConnectionWithDependencies:(RTC_OBJC_TYPE(RTCConfiguration) *)configuration
                        constraints:(RTC_OBJC_TYPE(RTCMediaConstraints) *)constraints
                       dependencies:(std::unique_ptr<webrtc::PeerConnectionDependencies>)dependencies
-                          delegate:(nullable id<RTC_OBJC_TYPE(RTCPeerConnectionDelegate)>)delegate;
+                          observer:(void *)observer;
 
 @end
 

--- a/sdk/objc/api/peerconnection/RTCPeerConnectionFactory.h
+++ b/sdk/objc/api/peerconnection/RTCPeerConnectionFactory.h
@@ -73,7 +73,7 @@ RTC_OBJC_EXPORT
 - (RTC_OBJC_TYPE(RTCPeerConnection) *)
     peerConnectionWithConfiguration:(RTC_OBJC_TYPE(RTCConfiguration) *)configuration
                         constraints:(RTC_OBJC_TYPE(RTCMediaConstraints) *)constraints
-                           delegate:(void *)observer;
+                           observer:(void *)observer;
 
 /** Set the options to be used for subsequently created RTCPeerConnections */
 - (void)setOptions:(nonnull RTC_OBJC_TYPE(RTCPeerConnectionFactoryOptions) *)options;

--- a/sdk/objc/api/peerconnection/RTCPeerConnectionFactory.mm
+++ b/sdk/objc/api/peerconnection/RTCPeerConnectionFactory.mm
@@ -285,12 +285,11 @@
 - (RTC_OBJC_TYPE(RTCPeerConnection) *)
     peerConnectionWithConfiguration:(RTC_OBJC_TYPE(RTCConfiguration) *)configuration
                         constraints:(RTC_OBJC_TYPE(RTCMediaConstraints) *)constraints
-                           delegate:
-                               (nullable id<RTC_OBJC_TYPE(RTCPeerConnectionDelegate)>)delegate {
+                           observer:(void *)observer {
   return [[RTC_OBJC_TYPE(RTCPeerConnection) alloc] initWithFactory:self
                                                      configuration:configuration
                                                        constraints:constraints
-                                                          delegate:delegate];
+                                                          observer:observer];
 }
 
 - (RTC_OBJC_TYPE(RTCPeerConnection) *)


### PR DESCRIPTION
Reapply the changes to pass the native observer object after picking up M84.