### PR TITLE
iOS and Mac fixes for M84

### DIFF
--- a/media/base/rtp_data_engine.cc
+++ b/media/base/rtp_data_engine.cc
@@ -237,6 +237,7 @@ void RtpDataMediaChannel::OnPacketReceived(rtc::CopyOnWriteBuffer packet,
   //              << ", len=" << data_len;
 
   ReceiveDataParams params;
+  params.type = cricket::DMT_BINARY;
   params.ssrc = header.ssrc;
   params.seq_num = header.seq_num;
   params.timestamp = header.timestamp;
@@ -267,7 +268,7 @@ bool RtpDataMediaChannel::SendData(const SendDataParams& params,
     return false;
   }
 
-  if (params.type != cricket::DMT_TEXT) {
+  if (params.type != cricket::DMT_BINARY) {
     RTC_LOG(LS_WARNING)
         << "Not sending data because binary type is unsupported.";
     return false;

--- a/modules/third_party/portaudio/BUILD.gn
+++ b/modules/third_party/portaudio/BUILD.gn
@@ -10,6 +10,8 @@ import("../../../webrtc.gni")
 
 rtc_library("mac_portaudio") {
   visibility = [ "../../audio_device:*" ]
+  # Don't warn about deprecated OSMemoryBarrier().
+  cflags = [ "-Wno-deprecated-declarations" ]
   sources = [
     "pa_memorybarrier.h",
     "pa_ringbuffer.c",

--- a/sdk/objc/api/peerconnection/RTCConfiguration.h
+++ b/sdk/objc/api/peerconnection/RTCConfiguration.h
@@ -226,6 +226,16 @@ RTC_OBJC_EXPORT
  */
 @property(nonatomic, assign) int rtcpVideoReportIntervalMs;
 
+/**
+ * Enable RTP data channel support. If disabled, SCTP data channels will be used.
+ */
+@property(nonatomic, assign) BOOL enableRtpDataChannel;
+
+/**
+ * Enable DTLS-SRTP key negotiation.
+ */
+@property(nonatomic, assign) BOOL enableDtlsSrtp;
+
 - (instancetype)init;
 
 @end

--- a/sdk/objc/api/peerconnection/RTCConfiguration.mm
+++ b/sdk/objc/api/peerconnection/RTCConfiguration.mm
@@ -57,6 +57,8 @@
 @synthesize cryptoOptions = _cryptoOptions;
 @synthesize rtcpAudioReportIntervalMs = _rtcpAudioReportIntervalMs;
 @synthesize rtcpVideoReportIntervalMs = _rtcpVideoReportIntervalMs;
+@synthesize enableRtpDataChannel = _enableRtpDataChannel;
+@synthesize enableDtlsSrtp = _enableDtlsSrtp;
 
 - (instancetype)init {
   // Copy defaults.
@@ -136,6 +138,8 @@
     _rtcpAudioReportIntervalMs = config.audio_rtcp_report_interval_ms();
     _rtcpVideoReportIntervalMs = config.video_rtcp_report_interval_ms();
     _allowCodecSwitching = config.allow_codec_switching.value_or(false);
+    _enableRtpDataChannel = config.enable_rtp_data_channel;
+    _enableDtlsSrtp = config.enable_dtls_srtp.value_or(true);
   }
   return self;
 }
@@ -143,7 +147,7 @@
 - (NSString *)description {
   static NSString *formatString = @"RTC_OBJC_TYPE(RTCConfiguration): "
                                   @"{\n%@\n%@\n%@\n%@\n%@\n%@\n%@\n%@\n%d\n%d\n%d\n%d\n%d\n%d\n"
-                                  @"%d\n%@\n%d\n%d\n%d\n%d\n%d\n%@\n%d\n}\n";
+                                  @"%d\n%@\n%d\n%d\n%d\n%d\n%d\n%@\n%d\n%d\n%d\n}\n";
 
   return [NSString
       stringWithFormat:formatString,
@@ -170,7 +174,9 @@
                        _maxIPv6Networks,
                        _activeResetSrtpParams,
                        _useMediaTransport,
-                       _enableDscp];
+                       _enableDscp,
+                       _enableRtpDataChannel,
+                       _enableDtlsSrtp];
 }
 
 #pragma mark - Private
@@ -268,6 +274,8 @@
   nativeConfig->set_audio_rtcp_report_interval_ms(_rtcpAudioReportIntervalMs);
   nativeConfig->set_video_rtcp_report_interval_ms(_rtcpVideoReportIntervalMs);
   nativeConfig->allow_codec_switching = _allowCodecSwitching;
+  nativeConfig->enable_rtp_data_channel = _enableRtpDataChannel;
+  nativeConfig->enable_dtls_srtp = _enableDtlsSrtp;
   return nativeConfig.release();
 }
 


### PR DESCRIPTION
* Expose EnableRtpDataChannel and EnableDtlsSrtp to Objective C
* Disable an accidentally-reenabled warning on Mac
* Assume the RTP data channel carries binary data.