### PR TITLE
Allow the use of Encryptors and Decryptors without generic header extension

### DIFF
--- a/audio/channel_receive.cc
+++ b/audio/channel_receive.cc
@@ -638,8 +638,8 @@ void ChannelReceive::ReceivePacket(const uint8_t* packet,
     payload = decrypted_audio_payload.data();
     payload_data_length = decrypted_audio_payload.size();
   } else if (crypto_options_.sframe.require_frame_encryption) {
-    RTC_DLOG(LS_ERROR)
-        << "FrameDecryptor required but not set, dropping packet";
+    // RTC_DLOG(LS_ERROR)
+    //     << "FrameDecryptor required but not set, dropping packet";
     payload_data_length = 0;
   }
 

--- a/modules/rtp_rtcp/source/rtp_sender_video.cc
+++ b/modules/rtp_rtcp/source/rtp_sender_video.cc
@@ -484,9 +484,9 @@ bool RTPSenderVideo::SendVideo(
   // TODO(benwright@webrtc.org) - Allocate enough to always encrypt inline.
   rtc::Buffer encrypted_video_payload;
   if (frame_encryptor_ != nullptr) {
-    if (!has_generic_descriptor) {
-      return false;
-    }
+    // if (!has_generic_descriptor) {
+    //   return false;
+    // }
 
     const size_t max_ciphertext_size =
         frame_encryptor_->GetMaxCiphertextByteSize(cricket::MEDIA_TYPE_VIDEO,

--- a/video/buffered_frame_decryptor.cc
+++ b/video/buffered_frame_decryptor.cc
@@ -63,15 +63,19 @@ BufferedFrameDecryptor::FrameDecision BufferedFrameDecryptor::DecryptFrame(
     return FrameDecision::kStash;
   }
   // When using encryption we expect the frame to have the generic descriptor.
-  if (frame->GetRtpVideoHeader().generic == absl::nullopt) {
-    RTC_LOG(LS_ERROR) << "No generic frame descriptor found dropping frame.";
-    return FrameDecision::kDrop;
-  }
+  // if (frame->GetRtpVideoHeader().generic == absl::nullopt) {
+  //   RTC_LOG(LS_ERROR) << "No generic frame descriptor found dropping frame.";
+  //   return FrameDecision::kDrop;
+  // }
   // Retrieve the maximum possible size of the decrypted payload.
   const size_t max_plaintext_byte_size =
       frame_decryptor_->GetMaxPlaintextByteSize(cricket::MEDIA_TYPE_VIDEO,
                                                 frame->size());
   RTC_CHECK_LE(max_plaintext_byte_size, frame->size());
+  // Place the decrypted frame inline into the existing frame.
+  rtc::ArrayView<uint8_t> encrypted_bitstream(frame->data(),
+                                              frame->size());
+
   // Place the decrypted frame inline into the existing frame.
   rtc::ArrayView<uint8_t> inline_decrypted_bitstream(frame->data(),
                                                      max_plaintext_byte_size);
@@ -85,7 +89,8 @@ BufferedFrameDecryptor::FrameDecision BufferedFrameDecryptor::DecryptFrame(
   // Attempt to decrypt the video frame.
   const FrameDecryptorInterface::Result decrypt_result =
       frame_decryptor_->Decrypt(cricket::MEDIA_TYPE_VIDEO, /*csrcs=*/{},
-                                additional_data, *frame,
+                                additional_data,
+                                encrypted_bitstream,
                                 inline_decrypted_bitstream);
   // Optionally call the callback if there was a change in status
   if (decrypt_result.status != last_status_) {


### PR DESCRIPTION
Also remove an annoying log statement that isn't needed and make on section of code more readable.