### PR TITLE
Expose native audio tracks

### DIFF
--- a/sdk/android/api/org/webrtc/AudioTrack.java
+++ b/sdk/android/api/org/webrtc/AudioTrack.java
@@ -24,7 +24,7 @@ public class AudioTrack extends MediaStreamTrack {
   }
 
   /** Returns a pointer to webrtc::AudioTrackInterface. */
-  long getNativeAudioTrack() {
+  public long getNativeAudioTrack() {
     return getNativeMediaStreamTrack();
   }
 

--- a/sdk/objc/api/peerconnection/RTCAudioTrack.h
+++ b/sdk/objc/api/peerconnection/RTCAudioTrack.h
@@ -23,6 +23,10 @@ RTC_OBJC_EXPORT
 /** The audio source for this audio track. */
 @property(nonatomic, readonly) RTC_OBJC_TYPE(RTCAudioSource) * source;
 
+/** Return the underlying native WebRTC audio track pointer.
+ */
+- (void *)getNativeTrack;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/sdk/objc/api/peerconnection/RTCAudioTrack.h
+++ b/sdk/objc/api/peerconnection/RTCAudioTrack.h
@@ -25,7 +25,7 @@ RTC_OBJC_EXPORT
 
 /** Return the underlying native WebRTC audio track pointer.
  */
-- (void *)getNativeTrack;
+- (void *)getNativeAudioTrack;
 
 @end
 

--- a/sdk/objc/api/peerconnection/RTCAudioTrack.mm
+++ b/sdk/objc/api/peerconnection/RTCAudioTrack.mm
@@ -18,7 +18,7 @@
 #include "rtc_base/checks.h"
 
 @implementation RTC_OBJC_TYPE (RTCAudioTrack) {
-  rtc::scoped_refptr<webrtc::AudioTrackInterface> _audioTrack;
+  rtc::scoped_refptr<webrtc::AudioTrackInterface> _nativeTrack;
 }
 
 @synthesize source = _source;
@@ -35,7 +35,7 @@
       factory.nativeFactory->CreateAudioTrack(nativeId, source.nativeAudioSource);
   if (self = [self initWithFactory:factory nativeTrack:track type:RTCMediaStreamTrackTypeAudio]) {
     _source = source;
-    _audioTrack = track;
+    _nativeTrack = track;
   }
   return self;
 }
@@ -62,7 +62,7 @@
 }
 
 - (void *)getNativeAudioTrack {
-  return _audioTrack.release();
+  return _nativeTrack.get();
 }
 
 #pragma mark - Private

--- a/sdk/objc/api/peerconnection/RTCAudioTrack.mm
+++ b/sdk/objc/api/peerconnection/RTCAudioTrack.mm
@@ -61,7 +61,7 @@
   return _source;
 }
 
-- (void *)getNativeTrack {
+- (void *)getNativeAudioTrack {
   return _audioTrack.release();
 }
 

--- a/sdk/objc/api/peerconnection/RTCAudioTrack.mm
+++ b/sdk/objc/api/peerconnection/RTCAudioTrack.mm
@@ -17,7 +17,9 @@
 
 #include "rtc_base/checks.h"
 
-@implementation RTC_OBJC_TYPE (RTCAudioTrack)
+@implementation RTC_OBJC_TYPE (RTCAudioTrack) {
+  rtc::scoped_refptr<webrtc::AudioTrackInterface> _audioTrack;
+}
 
 @synthesize source = _source;
 
@@ -33,6 +35,7 @@
       factory.nativeFactory->CreateAudioTrack(nativeId, source.nativeAudioSource);
   if (self = [self initWithFactory:factory nativeTrack:track type:RTCMediaStreamTrackTypeAudio]) {
     _source = source;
+    _audioTrack = track;
   }
   return self;
 }
@@ -56,6 +59,10 @@
     }
   }
   return _source;
+}
+
+- (void *)getNativeTrack {
+  return _audioTrack.release();
 }
 
 #pragma mark - Private

--- a/sdk/objc/api/peerconnection/RTCVideoTrack.h
+++ b/sdk/objc/api/peerconnection/RTCVideoTrack.h
@@ -35,7 +35,7 @@ RTC_OBJC_EXPORT
 
 /** Return the underlying native WebRTC video track pointer.
  */
-- (void *)getNativeTrack;
+- (void *)getNativeVideoTrack;
 
 @end
 

--- a/sdk/objc/api/peerconnection/RTCVideoTrack.h
+++ b/sdk/objc/api/peerconnection/RTCVideoTrack.h
@@ -33,9 +33,9 @@ RTC_OBJC_EXPORT
 /** Deregister a renderer. */
 - (void)removeRenderer:(id<RTC_OBJC_TYPE(RTCVideoRenderer)>)renderer;
 
-/** Return the underlying native WebRTC VideoTrack pointer.
+/** Return the underlying native WebRTC video track pointer.
  */
-- (void *)getNativeVideoTrack;
+- (void *)getNativeTrack;
 
 @end
 

--- a/sdk/objc/api/peerconnection/RTCVideoTrack.mm
+++ b/sdk/objc/api/peerconnection/RTCVideoTrack.mm
@@ -117,7 +117,7 @@
   [_adapters removeObjectAtIndex:indexToRemove];
 }
 
-- (void *)getNativeVideoTrack {
+- (void *)getNativeTrack {
   return _videoTrack.release();
 }
 

--- a/sdk/objc/api/peerconnection/RTCVideoTrack.mm
+++ b/sdk/objc/api/peerconnection/RTCVideoTrack.mm
@@ -18,7 +18,7 @@
 
 @implementation RTC_OBJC_TYPE (RTCVideoTrack) {
   NSMutableArray *_adapters;
-  rtc::scoped_refptr<webrtc::VideoTrackInterface> _videoTrack;
+  rtc::scoped_refptr<webrtc::VideoTrackInterface> _nativeTrack;
 }
 
 @synthesize source = _source;
@@ -35,7 +35,7 @@
                                               source.nativeVideoSource);
   if (self = [self initWithFactory:factory nativeTrack:track type:RTCMediaStreamTrackTypeVideo]) {
     _source = source;
-    _videoTrack = track;
+    _nativeTrack = track;
   }
   return self;
 }
@@ -118,7 +118,7 @@
 }
 
 - (void *)getNativeVideoTrack {
-  return _videoTrack.release();
+  return _nativeTrack.get();
 }
 
 #pragma mark - Private

--- a/sdk/objc/api/peerconnection/RTCVideoTrack.mm
+++ b/sdk/objc/api/peerconnection/RTCVideoTrack.mm
@@ -117,7 +117,7 @@
   [_adapters removeObjectAtIndex:indexToRemove];
 }
 
-- (void *)getNativeTrack {
+- (void *)getNativeVideoTrack {
   return _videoTrack.release();
 }
 


### PR DESCRIPTION
Also renaming the video track accessor for iOS (i.e. VideoTrack.getNativeTrack()).