### PR TITLE
Support setOrientation() API For CameraSession

### DIFF
--- a/sdk/android/api/org/webrtc/FileVideoCapturer.java
+++ b/sdk/android/api/org/webrtc/FileVideoCapturer.java
@@ -190,7 +190,7 @@ public class FileVideoCapturer implements VideoCapturer {
   }
 
   @Override
-  public void setOrientation(int orientation) {
+  public void setOrientation(Integer orientation) {
     // Empty on purpose
   }
 

--- a/sdk/android/api/org/webrtc/FileVideoCapturer.java
+++ b/sdk/android/api/org/webrtc/FileVideoCapturer.java
@@ -190,6 +190,11 @@ public class FileVideoCapturer implements VideoCapturer {
   }
 
   @Override
+  public void setOrientation(int orientation) {
+    // Empty on purpose
+  }
+
+  @Override
   public void dispose() {
     videoReader.close();
   }

--- a/sdk/android/api/org/webrtc/ScreenCapturerAndroid.java
+++ b/sdk/android/api/org/webrtc/ScreenCapturerAndroid.java
@@ -186,6 +186,11 @@ public class ScreenCapturerAndroid implements VideoCapturer, VideoSink {
     });
   }
 
+  @Override
+  public void setOrientation(int orientation) {
+    // Empty on purpose
+  }
+
   private void createVirtualDisplay() {
     surfaceTextureHelper.setTextureSize(width, height);
     virtualDisplay = mediaProjection.createVirtualDisplay("WebRTC_ScreenCapture", width, height,

--- a/sdk/android/api/org/webrtc/ScreenCapturerAndroid.java
+++ b/sdk/android/api/org/webrtc/ScreenCapturerAndroid.java
@@ -187,7 +187,7 @@ public class ScreenCapturerAndroid implements VideoCapturer, VideoSink {
   }
 
   @Override
-  public void setOrientation(int orientation) {
+  public void setOrientation(Integer orientation) {
     // Empty on purpose
   }
 

--- a/sdk/android/api/org/webrtc/VideoCapturer.java
+++ b/sdk/android/api/org/webrtc/VideoCapturer.java
@@ -41,6 +41,8 @@ public interface VideoCapturer {
 
   void changeCaptureFormat(int width, int height, int framerate);
 
+  void setOrientation(int orientation);
+
   /**
    * Perform any final cleanup here. No more capturing will be done after this call.
    */

--- a/sdk/android/api/org/webrtc/VideoCapturer.java
+++ b/sdk/android/api/org/webrtc/VideoCapturer.java
@@ -11,6 +11,7 @@
 package org.webrtc;
 
 import android.content.Context;
+import android.support.annotation.Nullable;
 
 // Base interface for all VideoCapturers to implement.
 public interface VideoCapturer {
@@ -41,7 +42,7 @@ public interface VideoCapturer {
 
   void changeCaptureFormat(int width, int height, int framerate);
 
-  void setOrientation(int orientation);
+  void setOrientation(@Nullable Integer orientation);
 
   /**
    * Perform any final cleanup here. No more capturing will be done after this call.

--- a/sdk/android/src/java/org/webrtc/Camera1Session.java
+++ b/sdk/android/src/java/org/webrtc/Camera1Session.java
@@ -312,6 +312,11 @@ class Camera1Session implements CameraSession {
     });
   }
 
+  @Override
+  public void setOrientation(int orientation) {
+    Logging.d(TAG, "(Ignored) Set Orientation: " + orientation);
+  }
+
   private int getFrameOrientation() {
     int rotation = CameraSession.getDeviceOrientation(applicationContext);
     if (info.facing == android.hardware.Camera.CameraInfo.CAMERA_FACING_BACK) {

--- a/sdk/android/src/java/org/webrtc/Camera1Session.java
+++ b/sdk/android/src/java/org/webrtc/Camera1Session.java
@@ -313,7 +313,7 @@ class Camera1Session implements CameraSession {
   }
 
   @Override
-  public void setOrientation(int orientation) {
+  public void setOrientation(Integer orientation) {
     Logging.d(TAG, "(Ignored) Set Orientation: " + orientation);
   }
 

--- a/sdk/android/src/java/org/webrtc/Camera2Session.java
+++ b/sdk/android/src/java/org/webrtc/Camera2Session.java
@@ -56,6 +56,7 @@ class Camera2Session implements CameraSession {
   // Initialized at start
   private CameraCharacteristics cameraCharacteristics;
   private int cameraOrientation;
+  private int deviceOrientation;
   private boolean isCameraFrontFacing;
   private int fpsUnitFactor;
   private CaptureFormat captureFormat;
@@ -307,6 +308,7 @@ class Camera2Session implements CameraSession {
       return;
     }
     cameraOrientation = cameraCharacteristics.get(CameraCharacteristics.SENSOR_ORIENTATION);
+    deviceOrientation = CameraSession.getDeviceOrientation(applicationContext);
     isCameraFrontFacing = cameraCharacteristics.get(CameraCharacteristics.LENS_FACING)
         == CameraMetadata.LENS_FACING_FRONT;
 
@@ -404,12 +406,22 @@ class Camera2Session implements CameraSession {
     }
   }
 
+  @Override
+  public void setOrientation(int orientation) {
+    checkIsOnCameraThread();
+    Logging.d(TAG, "Set Orientation: " + orientation);
+
+    // The device orientation is locked to portrait in Signal clients.
+    // Instead of using CameraSession.getDeviceOrientation(), rely
+    // on the client to indicate the current rotated orientation.
+    deviceOrientation = orientation;
+  }
+
   private int getFrameOrientation() {
-    int rotation = CameraSession.getDeviceOrientation(applicationContext);
     if (!isCameraFrontFacing) {
-      rotation = 360 - rotation;
+      deviceOrientation = 360 - deviceOrientation;
     }
-    return (cameraOrientation + rotation) % 360;
+    return (cameraOrientation + deviceOrientation) % 360;
   }
 
   private void checkIsOnCameraThread() {

--- a/sdk/android/src/java/org/webrtc/CameraCapturer.java
+++ b/sdk/android/src/java/org/webrtc/CameraCapturer.java
@@ -313,6 +313,20 @@ abstract class CameraCapturer implements CameraVideoCapturer {
   }
 
   @Override
+  public void setOrientation(int orientation) {
+    synchronized (stateLock) {
+      if (currentSession != null) {
+        cameraThreadHandler.post(new Runnable() {
+          @Override
+          public void run() {
+            currentSession.setOrientation(orientation);
+          }
+        });
+      }
+    }
+  }
+
+  @Override
   public void changeCaptureFormat(int width, int height, int framerate) {
     Logging.d(TAG, "changeCaptureFormat: " + width + "x" + height + "@" + framerate);
     synchronized (stateLock) {

--- a/sdk/android/src/java/org/webrtc/CameraCapturer.java
+++ b/sdk/android/src/java/org/webrtc/CameraCapturer.java
@@ -313,17 +313,17 @@ abstract class CameraCapturer implements CameraVideoCapturer {
   }
 
   @Override
-  public void setOrientation(int orientation) {
-    synchronized (stateLock) {
-      if (currentSession != null) {
-        cameraThreadHandler.post(new Runnable() {
-          @Override
-          public void run() {
+  public void setOrientation(@Nullable Integer orientation) {
+    cameraThreadHandler.post(new Runnable() {
+      @Override
+      public void run() {
+        synchronized (stateLock) {
+          if (currentSession != null) {
             currentSession.setOrientation(orientation);
           }
-        });
+        }
       }
-    }
+    });
   }
 
   @Override

--- a/sdk/android/src/java/org/webrtc/CameraSession.java
+++ b/sdk/android/src/java/org/webrtc/CameraSession.java
@@ -39,6 +39,8 @@ interface CameraSession {
    */
   void stop();
 
+  void setOrientation(int orientation);
+
   static int getDeviceOrientation(Context context) {
     final WindowManager wm = (WindowManager) context.getSystemService(Context.WINDOW_SERVICE);
     switch (wm.getDefaultDisplay().getRotation()) {

--- a/sdk/android/src/java/org/webrtc/CameraSession.java
+++ b/sdk/android/src/java/org/webrtc/CameraSession.java
@@ -12,6 +12,7 @@ package org.webrtc;
 
 import android.content.Context;
 import android.graphics.Matrix;
+import android.support.annotation.Nullable;
 import android.view.WindowManager;
 import android.view.Surface;
 
@@ -39,7 +40,7 @@ interface CameraSession {
    */
   void stop();
 
-  void setOrientation(int orientation);
+  void setOrientation(@Nullable Integer orientation);
 
   static int getDeviceOrientation(Context context) {
     final WindowManager wm = (WindowManager) context.getSystemService(Context.WINDOW_SERVICE);


### PR DESCRIPTION
Since the Signal client locks device orientation (to portrait), they need some mechanism to update the CameraSession with the updated orientation when it changes. It is not reflected in the CameraSession.getDeviceOrientation() function.