### PR TITLE
Change Windows to use new ADM2

### DIFF
--- a/modules/audio_device/BUILD.gn
+++ b/modules/audio_device/BUILD.gn
@@ -158,6 +158,7 @@ rtc_library("audio_device_impl") {
     ":audio_device_buffer",
     ":audio_device_default",
     ":audio_device_generic",
+    ":audio_device_module_from_input_and_output",
     "../../api:array_view",
     "../../api:refcountedbase",
     "../../api:scoped_refptr",

--- a/modules/audio_device/include/audio_device_factory.cc
+++ b/modules/audio_device/include/audio_device_factory.cc
@@ -37,13 +37,6 @@ CreateWindowsCoreAudioAudioDeviceModuleForTest(
     TaskQueueFactory* task_queue_factory,
     bool automatic_restart) {
   RTC_DLOG(INFO) << __FUNCTION__;
-  // Returns NULL if Core Audio is not supported or if COM has not been
-  // initialized correctly using webrtc_win::ScopedCOMInitializer.
-  if (!webrtc_win::core_audio_utility::IsSupported()) {
-    RTC_LOG(LS_ERROR)
-        << "Unable to create ADM since Core Audio is not supported";
-    return nullptr;
-  }
   return CreateWindowsCoreAudioAudioDeviceModuleFromInputAndOutput(
       std::make_unique<webrtc_win::CoreAudioInput>(automatic_restart),
       std::make_unique<webrtc_win::CoreAudioOutput>(automatic_restart),

--- a/modules/audio_device/win/audio_device_module_win.cc
+++ b/modules/audio_device/win/audio_device_module_win.cc
@@ -175,14 +175,24 @@ class WindowsAudioDeviceModule : public AudioDeviceModuleForTest {
     RTC_LOG(INFO) << __FUNCTION__;
     RTC_DCHECK_RUN_ON(&thread_checker_);
     RETURN_IF_OUTPUT_RESTARTS(0);
-    return output_->NumDevices();
+    int16_t num_devices = output_->NumDevices();
+    if (num_devices == 0) {
+        return 0;
+    } else {
+        return num_devices + 2;
+    }
   }
 
   int16_t RecordingDevices() override {
     RTC_LOG(INFO) << __FUNCTION__;
     RTC_DCHECK_RUN_ON(&thread_checker_);
     RETURN_IF_INPUT_RESTARTS(0);
-    return input_->NumDevices();
+    int16_t num_devices = input_->NumDevices();
+    if (num_devices == 0) {
+      return 0;
+    } else {
+      return num_devices + 2;
+    }
   }
 
   int32_t PlayoutDeviceName(uint16_t index,

--- a/modules/audio_device/win/core_audio_base_win.cc
+++ b/modules/audio_device/win/core_audio_base_win.cc
@@ -529,7 +529,9 @@ bool CoreAudioBase::Init() {
     return false;
   }
   RTC_DLOG(INFO) << "audio session state: " << SessionStateToString(state);
-  RTC_DCHECK_EQ(state, AudioSessionStateInactive);
+
+  // Removing this check to support multiple instances in debug builds.
+  //RTC_DCHECK_EQ(state, AudioSessionStateInactive);
 
   // Register the client to receive notifications of session events, including
   // changes in the stream state.

--- a/modules/audio_device/win/core_audio_input_win.cc
+++ b/modules/audio_device/win/core_audio_input_win.cc
@@ -270,7 +270,8 @@ bool CoreAudioInput::OnDataCallback(uint64_t device_frequency) {
     // This is concurrent examination of state across multiple threads so will
     // be somewhat error prone, but we should still be defensive and not use
     // audio_capture_client_ if we know it's not there.
-    return false;
+    RTC_LOG(LS_WARNING) << "CoreAudioInput::OnDataCallback not yet ready";
+    return true;
   }
   if (num_data_callbacks_ == 0) {
     RTC_LOG(INFO) << "--- Input audio stream is alive ---";


### PR DESCRIPTION
WebRTC provides a newer ADM implementation for Windows, which uses Core Audio APIs only. The upstream project team recommends the use of this newer "ADM2" going forward, as discussed in this thread and others: https://groups.google.com/g/discuss-webrtc/c/G0UhzIF6-Jg/m/c9lGVQx2BAAJ

For our use, since the Signal client only supports Windows 7 and later, we should switch to use the new ADM for Windows and eschew the old one because of numerous issues (devices not recording, crashes, AEC issues, etc.). The new ADM is created in a slightly different manner (with its own factory), but this PR embeds it using the existing ADM model.