### PR TITLE
Make bitrate adjustments for lower bandwidth conditions

### DIFF
--- a/api/transport/bitrate_settings.h
+++ b/api/transport/bitrate_settings.h
@@ -41,8 +41,12 @@ struct BitrateConstraints {
   int start_bitrate_bps = kDefaultStartBitrateBps;
   int max_bitrate_bps = -1;
 
- private:
+ public:
+  // Make public to share default value for estimation and allocation.
   static constexpr int kDefaultStartBitrateBps = 100000;
+  // If < 1.0, will try to underutilize the estimated bandwidth, to
+  // help reduce overshoots of the actual bandwidth.
+  static constexpr double kBitrateAllocationMultiplier = 0.9;
 };
 
 }  // namespace webrtc

--- a/api/transport/bitrate_settings.h
+++ b/api/transport/bitrate_settings.h
@@ -42,7 +42,7 @@ struct BitrateConstraints {
   int max_bitrate_bps = -1;
 
  private:
-  static constexpr int kDefaultStartBitrateBps = 300000;
+  static constexpr int kDefaultStartBitrateBps = 100000;
 };
 
 }  // namespace webrtc

--- a/call/bitrate_allocator.cc
+++ b/call/bitrate_allocator.cc
@@ -17,6 +17,7 @@
 #include <utility>
 
 #include "absl/algorithm/container.h"
+#include "api/transport/bitrate_settings.h"
 #include "api/units/data_rate.h"
 #include "api/units/time_delta.h"
 #include "rtc_base/checks.h"
@@ -34,7 +35,7 @@ using bitrate_allocator_impl::AllocatableTrack;
 // Allow packets to be transmitted in up to 2 times max video bitrate if the
 // bandwidth estimate allows it.
 const uint8_t kTransmissionMaxBitrateMultiplier = 2;
-const int kDefaultBitrateBps = 100000;
+const int kDefaultBitrateBps = BitrateConstraints::kDefaultStartBitrateBps;
 
 // Require a bitrate increase of max(10%, 20kbps) to resume paused streams.
 const double kToggleFactor = 0.1;
@@ -380,8 +381,8 @@ void BitrateAllocator::OnNetworkEstimateChanged(TargetTransferRate msg) {
   last_target_bps_ = msg.target_rate.bps();
   last_stable_target_bps_ = msg.stable_target_rate.bps();
 
-  // Try to underutilize the estimated bandwidth to reduce overshoots.
-  last_target_bps_ = last_target_bps_ * 0.9;
+  // Adjust the estimated target bitrate as configured.
+  last_target_bps_ = last_target_bps_ * BitrateConstraints::kBitrateAllocationMultiplier;
 
   last_non_zero_bitrate_bps_ =
       last_target_bps_ > 0 ? last_target_bps_ : last_non_zero_bitrate_bps_;

--- a/call/bitrate_allocator.cc
+++ b/call/bitrate_allocator.cc
@@ -34,7 +34,7 @@ using bitrate_allocator_impl::AllocatableTrack;
 // Allow packets to be transmitted in up to 2 times max video bitrate if the
 // bandwidth estimate allows it.
 const uint8_t kTransmissionMaxBitrateMultiplier = 2;
-const int kDefaultBitrateBps = 300000;
+const int kDefaultBitrateBps = 100000;
 
 // Require a bitrate increase of max(10%, 20kbps) to resume paused streams.
 const double kToggleFactor = 0.1;
@@ -379,6 +379,10 @@ void BitrateAllocator::OnNetworkEstimateChanged(TargetTransferRate msg) {
   RTC_DCHECK_RUN_ON(&sequenced_checker_);
   last_target_bps_ = msg.target_rate.bps();
   last_stable_target_bps_ = msg.stable_target_rate.bps();
+
+  // Try to underutilize the estimated bandwidth to reduce overshoots.
+  last_target_bps_ = last_target_bps_ * 0.9;
+
   last_non_zero_bitrate_bps_ =
       last_target_bps_ > 0 ? last_target_bps_ : last_non_zero_bitrate_bps_;
 

--- a/pc/peer_connection_factory.cc
+++ b/pc/peer_connection_factory.cc
@@ -362,7 +362,7 @@ std::unique_ptr<Call> PeerConnectionFactory::CreateCall_w(
   FieldTrialParameter<DataRate> min_bandwidth("min",
                                               DataRate::KilobitsPerSec(30));
   FieldTrialParameter<DataRate> start_bandwidth("start",
-                                                DataRate::KilobitsPerSec(100));
+                                                DataRate::BitsPerSec(BitrateConstraints::kDefaultStartBitrateBps));
   FieldTrialParameter<DataRate> max_bandwidth("max",
                                               DataRate::KilobitsPerSec(2000));
   ParseFieldTrial({&min_bandwidth, &start_bandwidth, &max_bandwidth},

--- a/pc/peer_connection_factory.cc
+++ b/pc/peer_connection_factory.cc
@@ -362,7 +362,7 @@ std::unique_ptr<Call> PeerConnectionFactory::CreateCall_w(
   FieldTrialParameter<DataRate> min_bandwidth("min",
                                               DataRate::KilobitsPerSec(30));
   FieldTrialParameter<DataRate> start_bandwidth("start",
-                                                DataRate::KilobitsPerSec(300));
+                                                DataRate::KilobitsPerSec(100));
   FieldTrialParameter<DataRate> max_bandwidth("max",
                                               DataRate::KilobitsPerSec(2000));
   ParseFieldTrial({&min_bandwidth, &start_bandwidth, &max_bandwidth},

--- a/rtc_tools/rtc_event_log_visualizer/analyzer.cc
+++ b/rtc_tools/rtc_event_log_visualizer/analyzer.cc
@@ -21,6 +21,7 @@
 #include "absl/algorithm/container.h"
 #include "absl/strings/string_view.h"
 #include "api/function_view.h"
+#include "api/transport/bitrate_settings.h"
 #include "api/transport/field_trial_based_config.h"
 #include "api/transport/goog_cc_factory.h"
 #include "call/audio_receive_stream.h"
@@ -1199,11 +1200,10 @@ void EventLogAnalyzer::CreateSendSideBweSimulationGraph(Plot* plot) {
   auto factory = GoogCcNetworkControllerFactory();
   TimeDelta process_interval = factory.GetProcessInterval();
   // TODO(holmer): Log the call config and use that here instead.
-  static const uint32_t kDefaultStartBitrateBps = 100000;
   NetworkControllerConfig cc_config;
   cc_config.constraints.at_time = Timestamp::Micros(clock.TimeInMicroseconds());
   cc_config.constraints.starting_rate =
-      DataRate::BitsPerSec(kDefaultStartBitrateBps);
+      DataRate::BitsPerSec(BitrateConstraints::kDefaultStartBitrateBps);
   cc_config.event_log = &null_event_log;
   auto goog_cc = factory.Create(cc_config);
 
@@ -1380,9 +1380,8 @@ void EventLogAnalyzer::CreateReceiveSideBweSimulationGraph(Plot* plot) {
     }
 
    private:
-    // We don't know the start bitrate, but assume that it is the default 100
-    // kbps.
-    uint32_t last_bitrate_bps_ = 100000;
+    // We don't know the start bitrate, but assume that it is the default.
+    uint32_t last_bitrate_bps_ = BitrateConstraints::kDefaultStartBitrateBps;
     bool bitrate_updated_ = false;
   };
 

--- a/rtc_tools/rtc_event_log_visualizer/analyzer.cc
+++ b/rtc_tools/rtc_event_log_visualizer/analyzer.cc
@@ -1199,7 +1199,7 @@ void EventLogAnalyzer::CreateSendSideBweSimulationGraph(Plot* plot) {
   auto factory = GoogCcNetworkControllerFactory();
   TimeDelta process_interval = factory.GetProcessInterval();
   // TODO(holmer): Log the call config and use that here instead.
-  static const uint32_t kDefaultStartBitrateBps = 300000;
+  static const uint32_t kDefaultStartBitrateBps = 100000;
   NetworkControllerConfig cc_config;
   cc_config.constraints.at_time = Timestamp::Micros(clock.TimeInMicroseconds());
   cc_config.constraints.starting_rate =
@@ -1380,9 +1380,9 @@ void EventLogAnalyzer::CreateReceiveSideBweSimulationGraph(Plot* plot) {
     }
 
    private:
-    // We don't know the start bitrate, but assume that it is the default 300
+    // We don't know the start bitrate, but assume that it is the default 100
     // kbps.
-    uint32_t last_bitrate_bps_ = 300000;
+    uint32_t last_bitrate_bps_ = 100000;
     bool bitrate_updated_ = false;
   };
 


### PR DESCRIPTION
Set initial bitrate to 100kbps (instead of 300kbps) to avoid initial freeze ups and to work better with lower bandwidth conditions.

Reduce target bitrate allocation by 10% to slightly underutilize the estimated bandwidth, which helps reduce overshoots in lower bandwidth conditions.