### PR TITLE
Changes to get WebRTC building for Catalyst

### DIFF
--- a/examples/BUILD.gn
+++ b/examples/BUILD.gn
@@ -346,10 +346,12 @@ if (is_ios || (is_mac && target_cpu != "x86")) {
         "../sdk:mediaconstraints_objc",
         "../sdk:peerconnectionfactory_base_objc",
         "../sdk:peerconnectionfactory_base_objc",
-        "../sdk:ui_objc",
         "../sdk:videocapture_objc",
         "../sdk:videocodec_objc",
       ]
+      if (rtc_use_opengl_rendering) {
+        deps += [ "../sdk:opengl_ui_objc" ]
+      }
       if (rtc_use_metal_rendering) {
         deps += [ "../sdk:metal_objc" ]
       }
@@ -502,12 +504,15 @@ if (is_ios || (is_mac && target_cpu != "x86")) {
         "../sdk:default_codec_factory_objc",
         "../sdk:helpers_objc",
         "../sdk:native_api",
-        "../sdk:ui_objc",
         "../sdk:videocapture_objc",
         "../sdk:videotoolbox_objc",
       ]
 
-      if (current_cpu == "arm64") {
+      if (rtc_use_opengl_rendering) {
+        deps += [ "../sdk:opengl_ui_objc" ]
+      }
+
+      if (rtc_use_metal_rendering) {
         deps += [ "../sdk:metal_objc" ]
       }
     }
@@ -546,9 +551,9 @@ if (is_ios || (is_mac && target_cpu != "x86")) {
         "../sdk:helpers_objc",
         "../sdk:mediaconstraints_objc",
         "../sdk:metal_objc",
+        "../sdk:opengl_ui_objc",
         "../sdk:peerconnectionfactory_base_objc",
         "../sdk:peerconnectionfactory_base_objc",
-        "../sdk:ui_objc",
         "../sdk:videocapture_objc",
         "../sdk:videocodec_objc",
       ]

--- a/ringrtc_overrides/libvpx/BUILD.gn
+++ b/ringrtc_overrides/libvpx/BUILD.gn
@@ -1,0 +1,395 @@
+# Copyright 2014 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import("//build/config/android/config.gni")
+import("//build/config/arm.gni")
+import("//build/config/chromeos/ui_mode.gni")
+import("//build/config/ios/config.gni")
+import("//build/config/sanitizers/sanitizers.gni")
+import("//third_party/libvpx/libvpx_srcs.gni")
+import("//third_party/nasm/nasm_assemble.gni")
+
+# Sets the architecture name for building libvpx.
+if (current_cpu == "x86") {
+  cpu_arch_full = "ia32"
+} else if (current_cpu == "x64") {
+  # As "nasm" does not embed the required LC_BUILD_VERSION section in object
+  # files, it is not possible to build optimised version of the code if the
+  # target is iOS under "catalyst" environment. This version is not shipped,
+  # so there is no concern about performance.
+  # TODO(crbug.com/1145197): Remove this exception once "nasm" has support
+  # for embedding the correct LD_BUILD_VERSION section.
+  if (is_msan || (is_ios && target_environment == "catalyst")) {
+    cpu_arch_full = "generic"
+  } else {
+    cpu_arch_full = "x64"
+  }
+} else if (current_cpu == "arm") {
+  if (is_chromeos_ash) {
+    # ChromeOS gets highbd vp9 but other arm targets do not.
+    cpu_arch_full = "arm-neon-highbd"
+  } else if (arm_use_neon) {
+    cpu_arch_full = "arm-neon"
+  } else if (is_android) {
+    cpu_arch_full = "arm-neon-cpu-detect"
+  } else {
+    cpu_arch_full = "arm"
+  }
+} else if (current_cpu == "arm64") {
+  if (is_chromeos_ash || is_win || is_mac || (is_ios && target_environment == "catalyst")) {
+    cpu_arch_full = "arm64-highbd"
+  } else {
+    cpu_arch_full = current_cpu
+  }
+} else {
+  cpu_arch_full = current_cpu
+}
+
+source_dir = "../../third_party/libvpx/source"
+
+if (is_nacl) {
+  platform_include_dir = "$source_dir/config/nacl"
+} else {
+  # The mac configurations are currently a relic. They were useful when
+  # x86inc.asm did not work for MACH_O but now the build is identical to the
+  # linux config. iOS for arm on the other hand needs an apple-specific twist in
+  # vpx_config.asm
+  if (is_ios && current_cpu == "arm") {
+    os_category = current_os
+  } else if (is_posix || is_fuchsia) {
+    # Should cover linux, fuchsia, mac, and the ios simulator.
+    os_category = "linux"
+  } else {  # This should only match windows.
+    os_category = current_os
+  }
+  platform_include_dir = "$source_dir/config/$os_category/$cpu_arch_full"
+}
+
+libvpx_include_dirs = [
+  "$source_dir/config",
+  platform_include_dir,
+  "$source_dir/libvpx",
+]
+
+config("libvpx_config") {
+  include_dirs = libvpx_include_dirs
+
+  # gn orders flags on a target before flags from configs. The default config
+  # adds -Wall, and these flags have to be after -Wall -- so they need to come
+  # from a config and can't be on the target directly.
+  if (is_clang) {
+    cflags = [
+      # libvpx heavily relies on implicit enum casting.
+      "-Wno-conversion",
+
+      # libvpx does `if ((a == b))` in some places.
+      "-Wno-parentheses-equality",
+
+      # libvpx has many static functions in header, which trigger this warning.
+      "-Wno-unused-function",
+    ]
+
+    # Fixes a mac / ios simulator link error for vpx_scaled_2d:
+    # Undefined symbols for architecture x86_64:
+    # "_vpx_scaled_2d", referenced from:
+    # _vp9_scale_and_extend_frame_c in libvpx.a(vp9_frame_scale.o)
+    # (maybe you meant: _vpx_scaled_2d_ssse3)
+    # ld: symbol(s) not found for architecture x86_64
+    if (is_mac || (is_ios && (current_cpu == "x86" || current_cpu == "x64"))) {
+      cflags += [ "-fno-common" ]
+    }
+  } else if (!is_win) {
+    cflags = [
+      "-Wno-unused-function",
+      "-Wno-sign-compare",
+    ]
+  }
+}
+
+# This config is applied to targets that depend on libvpx.
+config("libvpx_external_config") {
+  include_dirs = [ "$source_dir/libvpx" ]
+}
+
+if (current_cpu == "x86" || (current_cpu == "x64" && !is_msan)) {
+  nasm_assemble("libvpx_asm") {
+    if (current_cpu == "x86") {
+      sources = libvpx_srcs_x86_assembly
+    } else if (current_cpu == "x64") {
+      sources = libvpx_srcs_x86_64_assembly
+    }
+
+    defines = [ "CHROMIUM" ]
+    if (is_android) {
+      # On Android, define __ANDROID__ to use alternative standard library
+      # functions.
+      defines += [ "__ANDROID__" ]
+    }
+    include_dirs = libvpx_include_dirs
+  }
+}
+
+if (current_cpu == "x86" || (current_cpu == "x64" && !is_msan)) {
+  # The following targets are deliberately source_set rather than
+  # static_library. The :libvpx target exposes these intrinsic implementations
+  # via global function pointer symbols, which hides the object dependency at
+  # link time. On Mac, this results in undefined references to the intrinsic
+  # symbols.
+
+  source_set("libvpx_intrinsics_mmx") {
+    configs -= [ "//build/config/compiler:chromium_code" ]
+    configs += [ "//build/config/compiler:no_chromium_code" ]
+    configs += [ ":libvpx_config" ]
+    if (!is_win) {
+      cflags = [ "-mmmx" ]
+    }
+    if (current_cpu == "x86") {
+      sources = libvpx_srcs_x86_mmx
+    } else if (current_cpu == "x64") {
+      sources = libvpx_srcs_x86_64_mmx
+    }
+  }
+
+  source_set("libvpx_intrinsics_sse2") {
+    configs -= [ "//build/config/compiler:chromium_code" ]
+    configs += [ "//build/config/compiler:no_chromium_code" ]
+    configs += [ ":libvpx_config" ]
+    if (!is_win || is_clang) {
+      cflags = [ "-msse2" ]
+    }
+    if (current_cpu == "x86") {
+      sources = libvpx_srcs_x86_sse2
+    } else if (current_cpu == "x64") {
+      sources = libvpx_srcs_x86_64_sse2
+    }
+  }
+
+  source_set("libvpx_intrinsics_ssse3") {
+    configs -= [ "//build/config/compiler:chromium_code" ]
+    configs += [ "//build/config/compiler:no_chromium_code" ]
+    configs += [ ":libvpx_config" ]
+    if (!is_win || is_clang) {
+      cflags = [ "-mssse3" ]
+    }
+    if (current_cpu == "x86") {
+      sources = libvpx_srcs_x86_ssse3
+    } else if (current_cpu == "x64") {
+      sources = libvpx_srcs_x86_64_ssse3
+    }
+  }
+
+  source_set("libvpx_intrinsics_sse4_1") {
+    configs -= [ "//build/config/compiler:chromium_code" ]
+    configs += [ "//build/config/compiler:no_chromium_code" ]
+    configs += [ ":libvpx_config" ]
+    if (!is_win || is_clang) {
+      cflags = [ "-msse4.1" ]
+    }
+    if (current_cpu == "x86") {
+      sources = libvpx_srcs_x86_sse4_1
+    } else if (current_cpu == "x64") {
+      sources = libvpx_srcs_x86_64_sse4_1
+    }
+  }
+
+  source_set("libvpx_intrinsics_avx") {
+    configs -= [ "//build/config/compiler:chromium_code" ]
+    configs += [ "//build/config/compiler:no_chromium_code" ]
+    configs += [ ":libvpx_config" ]
+    if (is_win) {
+      cflags = [ "/arch:AVX" ]
+    } else {
+      cflags = [ "-mavx" ]
+    }
+    if (current_cpu == "x86") {
+      sources = libvpx_srcs_x86_avx
+    } else if (current_cpu == "x64") {
+      sources = libvpx_srcs_x86_64_avx
+    }
+  }
+
+  source_set("libvpx_intrinsics_avx2") {
+    configs -= [ "//build/config/compiler:chromium_code" ]
+    configs += [ "//build/config/compiler:no_chromium_code" ]
+    configs += [ ":libvpx_config" ]
+    if (is_win) {
+      cflags = [ "/arch:AVX2" ]
+    } else {
+      cflags = [ "-mavx2" ]
+    }
+    if (current_cpu == "x86") {
+      sources = libvpx_srcs_x86_avx2
+    } else if (current_cpu == "x64") {
+      sources = libvpx_srcs_x86_64_avx2
+    }
+  }
+
+  source_set("libvpx_intrinsics_avx512") {
+    configs -= [ "//build/config/compiler:chromium_code" ]
+    configs += [ "//build/config/compiler:no_chromium_code" ]
+    configs += [ ":libvpx_config" ]
+    if (is_win) {
+      # clang-cl does not accept this flag.
+      # https://bugs.chromium.org/p/chromium/issues/detail?id=783370
+      cflags = [ "/arch:AVX512" ]
+    } else {
+      cflags = [
+        "-mavx512f",
+        "-mavx512cd",
+        "-mavx512bw",
+        "-mavx512dq",
+        "-mavx512vl",
+      ]
+    }
+    if (current_cpu == "x86") {
+      sources = libvpx_srcs_x86_avx512
+    } else if (current_cpu == "x64") {
+      sources = libvpx_srcs_x86_64_avx512
+    }
+  }
+}
+
+if (cpu_arch_full == "arm-neon-cpu-detect") {
+  static_library("libvpx_intrinsics_neon") {
+    configs -= [ "//build/config/compiler:compiler_arm_fpu" ]
+    configs += [ ":libvpx_config" ]
+    cflags = [ "-mfpu=neon" ]
+    sources = libvpx_srcs_arm_neon_cpu_detect_neon
+  }
+}
+
+if (current_cpu == "arm") {
+  if (cpu_arch_full == "arm-neon") {
+    arm_assembly_sources = libvpx_srcs_arm_neon_assembly
+  } else if (cpu_arch_full == "arm-neon-highbd") {
+    arm_assembly_sources = libvpx_srcs_arm_neon_highbd_assembly
+  } else if (cpu_arch_full == "arm-neon-cpu-detect") {
+    arm_assembly_sources = libvpx_srcs_arm_neon_cpu_detect_assembly
+  } else {
+    arm_assembly_sources = libvpx_srcs_arm_assembly
+  }
+}
+
+# Converts ARM assembly files to GAS style.
+if (current_cpu == "arm" && arm_assembly_sources != []) {
+  action_foreach("convert_arm_assembly") {
+    script = "//third_party/libvpx/run_perl.py"
+    sources = arm_assembly_sources
+    gen_file =
+        get_label_info("//third_party/libvpx/source/libvpx", "root_gen_dir") +
+        "/{{source_root_relative_dir}}/{{source_file_part}}.S"
+    outputs = [ gen_file ]
+    if (is_ios) {
+      ads2gas_script =
+          "//third_party/libvpx/source/libvpx/build/make/ads2gas_apple.pl"
+    } else {
+      ads2gas_script =
+          "//third_party/libvpx/source/libvpx/build/make/ads2gas.pl"
+    }
+    args = [
+      "-s",
+      rebase_path(ads2gas_script, root_build_dir),
+      "-i",
+      "{{source}}",
+      "-o",
+      rebase_path(gen_file, root_build_dir),
+    ]
+  }
+
+  static_library("libvpx_assembly_arm") {
+    sources = get_target_outputs(":convert_arm_assembly")
+    configs -= [ "//build/config/compiler:compiler_arm_fpu" ]
+    configs += [ ":libvpx_config" ]
+    if (cpu_arch_full == "arm-neon" || cpu_arch_full == "arm-neon-cpu-detect" ||
+        cpu_arch_full == "arm-neon-highbd") {
+      asmflags = [ "-mfpu=neon" ]
+
+      # allow asm files to include generated sources which match the source
+      # tree layout, e.g., vpx_dsp/arm/...
+      include_dirs = [ get_label_info("//third_party/libvpx/source/libvpx",
+                                      "target_gen_dir") ]
+    }
+    deps = [ ":convert_arm_assembly" ]
+  }
+}
+
+static_library("libvpx") {
+  if (!is_debug && (is_win || is_chromeos)) {
+    configs -= [ "//build/config/compiler:default_optimization" ]
+    configs += [ "//build/config/compiler:optimize_max" ]
+  }
+
+  if (is_nacl || cpu_arch_full == "generic") {
+    sources = libvpx_srcs_generic
+  } else if (current_cpu == "x86") {
+    sources = libvpx_srcs_x86
+  } else if (current_cpu == "x64") {
+    sources = libvpx_srcs_x86_64
+  } else if (current_cpu == "mipsel" || current_cpu == "mips64el") {
+    sources = libvpx_srcs_mips
+  } else if (current_cpu == "arm") {
+    if (is_chromeos_ash) {
+      sources = libvpx_srcs_arm_neon_highbd
+    } else if (arm_use_neon) {
+      sources = libvpx_srcs_arm_neon
+    } else if (is_android) {
+      sources = libvpx_srcs_arm_neon_cpu_detect
+    } else {
+      sources = libvpx_srcs_arm
+    }
+  } else if (current_cpu == "arm64") {
+    if (cpu_arch_full == "arm64-highbd") {
+      sources = libvpx_srcs_arm64_highbd
+    } else {
+      sources = libvpx_srcs_arm64
+    }
+  }
+
+  configs -= [ "//build/config/compiler:chromium_code" ]
+  configs += [ "//build/config/compiler:no_chromium_code" ]
+  configs += [ ":libvpx_config" ]
+  deps = []
+  if (cpu_arch_full == "x86" || cpu_arch_full == "x64") {
+    deps += [
+      ":libvpx_asm",
+      ":libvpx_intrinsics_avx",
+      ":libvpx_intrinsics_avx2",
+      ":libvpx_intrinsics_avx512",
+      ":libvpx_intrinsics_mmx",
+      ":libvpx_intrinsics_sse2",
+      ":libvpx_intrinsics_sse4_1",
+      ":libvpx_intrinsics_ssse3",
+    ]
+  }
+  if (cpu_arch_full == "arm-neon-cpu-detect") {
+    deps += [ ":libvpx_intrinsics_neon" ]
+  }
+  if (is_android) {
+    deps += [ "//third_party/android_ndk:cpu_features" ]
+  }
+  if (current_cpu == "arm" && arm_assembly_sources != []) {
+    deps += [ ":libvpx_assembly_arm" ]
+  }
+
+  public_configs = [ ":libvpx_external_config" ]
+}
+
+static_library("libvp9rc") {
+  if (!is_debug && is_win) {
+    configs -= [ "//build/config/compiler:default_optimization" ]
+    configs += [ "//build/config/compiler:optimize_max" ]
+  }
+
+  sources = [
+    "//third_party/libvpx/source/libvpx/vp9/ratectrl_rtc.cc",
+    "//third_party/libvpx/source/libvpx/vp9/ratectrl_rtc.h",
+  ]
+
+  configs -= [ "//build/config/compiler:chromium_code" ]
+  configs += [ "//build/config/compiler:no_chromium_code" ]
+  configs += [ ":libvpx_config" ]
+  public_deps = [ ":libvpx" ]
+
+  public_configs = [ ":libvpx_external_config" ]
+}

--- a/sdk/BUILD.gn
+++ b/sdk/BUILD.gn
@@ -423,7 +423,7 @@ if (is_ios || is_mac) {
       ]
     }
 
-    rtc_library("video_objc") {
+    rtc_library("opengl_objc") {
       sources = [
         "objc/components/renderer/opengl/RTCDefaultShader.h",
         "objc/components/renderer/opengl/RTCDefaultShader.mm",
@@ -475,7 +475,7 @@ if (is_ios || is_mac) {
       ]
     }
 
-    rtc_library("ui_objc") {
+    rtc_library("opengl_ui_objc") {
       visibility = [ "*" ]
       allow_poison = [ "audio_codecs" ]  # TODO(bugs.webrtc.org/8396): Remove.
       if (is_ios) {
@@ -496,7 +496,7 @@ if (is_ios || is_mac) {
       deps = [
         ":base_objc",
         ":helpers_objc",
-        ":video_objc",
+        ":opengl_objc",
         ":videocapture_objc",
         ":videoframebuffer_objc",
       ]
@@ -541,7 +541,6 @@ if (is_ios || is_mac) {
         deps = [
           ":base_objc",
           ":peerconnectionfactory_base_objc",
-          ":video_objc",
           ":videoframebuffer_objc",
           "../api/video:video_frame",
           "../api/video:video_rtp_headers",
@@ -590,7 +589,6 @@ if (is_ios || is_mac) {
       deps = [
         ":base_objc",
         ":helpers_objc",
-        ":video_objc",
         ":videoframebuffer_objc",
         "../rtc_base/system:gcd_helpers",
       ]
@@ -942,7 +940,6 @@ if (is_ios || is_mac) {
         ":mediasource_objc",
         ":native_api",
         ":native_video",
-        ":video_objc",
         ":videoframebuffer_objc",
         ":videorendereradapter_objc",
         ":videosource_objc",
@@ -1023,7 +1020,6 @@ if (is_ios || is_mac) {
             ":native_api_audio_device_module",
             ":native_video",
             ":peerconnectionfactory_base_objc",
-            ":video_objc",
             ":video_toolbox_cc",
             ":videocapture_objc",
             ":videocodec_objc",
@@ -1041,6 +1037,10 @@ if (is_ios || is_mac) {
             "../system_wrappers",
             "//third_party/libyuv",
           ]
+
+          if (rtc_use_opengl_rendering) {
+            deps += [ ":opengl_objc" ]
+          }
 
           if (rtc_use_metal_rendering) {
             sources += [ "objc/unittests/RTCMTLVideoView_xctest.m" ]
@@ -1136,7 +1136,6 @@ if (is_ios || is_mac) {
           ":native_api",
           ":native_video",
           ":peerconnectionfactory_base_objc",
-          ":video_objc",
           ":videocapture_objc",
           ":videocodec_objc",
           ":videoframebuffer_objc",
@@ -1277,13 +1276,15 @@ if (is_ios || is_mac) {
           ":native_api",
           ":native_video",
           ":peerconnectionfactory_base_objc",
-          ":ui_objc",
           ":videocapture_objc",
           ":videocodec_objc",
           ":videotoolbox_objc",
           "../rtc_base:rtc_base_approved",
           "../ringrtc/rffi:libringrtc_rffi",
         ]
+        if (rtc_use_opengl_rendering) {
+          deps += [ ":opengl_ui_objc" ]
+        }
         if (rtc_use_metal_rendering) {
           deps += [ ":metal_objc" ]
         }
@@ -1298,7 +1299,6 @@ if (is_ios || is_mac) {
           "AVFoundation.framework",
           "CoreGraphics.framework",
           "CoreMedia.framework",
-          "GLKit.framework",
         ]
 
         configs += [
@@ -1409,8 +1409,8 @@ if (is_ios || is_mac) {
           ":default_codec_factory_objc",
           ":native_api",
           ":native_video",
+          ":opengl_ui_objc",
           ":peerconnectionfactory_base_objc",
-          ":ui_objc",
           ":videocapture_objc",
           ":videocodec_objc",
           ":videotoolbox_objc",

--- a/sdk/objc/components/video_codec/RTCVideoDecoderH264.mm
+++ b/sdk/objc/components/video_codec/RTCVideoDecoderH264.mm
@@ -209,7 +209,9 @@ void decompressionOutputCallback(void *decoderRef,
 #endif
 
   CFTypeRef keys[attributesSize] = {
-#if defined(WEBRTC_IOS)
+#if defined(WEBRTC_IOS) && TARGET_OS_MACCATALYST
+      kCVPixelBufferMetalCompatibilityKey,
+#elif defined(WEBRTC_IOS)
       kCVPixelBufferOpenGLESCompatibilityKey,
 #elif defined(WEBRTC_MAC)
       kCVPixelBufferOpenGLCompatibilityKey,

--- a/sdk/objc/components/video_codec/RTCVideoEncoderH264.mm
+++ b/sdk/objc/components/video_codec/RTCVideoEncoderH264.mm
@@ -594,7 +594,9 @@ NSUInteger GetMaxSampleRate(const webrtc::H264::ProfileLevelId &profile_level_id
   // buffers retrieved from the encoder's pixel buffer pool.
   const size_t attributesSize = 3;
   CFTypeRef keys[attributesSize] = {
-#if defined(WEBRTC_IOS)
+#if defined(WEBRTC_IOS) && TARGET_OS_MACCATALYST
+    kCVPixelBufferMetalCompatibilityKey,
+#elif defined(WEBRTC_IOS)
     kCVPixelBufferOpenGLESCompatibilityKey,
 #elif defined(WEBRTC_MAC)
     kCVPixelBufferOpenGLCompatibilityKey,

--- a/webrtc.gni
+++ b/webrtc.gni
@@ -179,7 +179,12 @@ declare_args() {
   }
 
   # Determines whether Metal is available on iOS/macOS.
-  rtc_use_metal_rendering = is_mac || (is_ios && current_cpu == "arm64")
+  rtc_use_metal_rendering =
+    is_mac || (is_ios && current_cpu == "arm64") ||
+    (is_ios && target_environment == "catalyst")
+
+  # Determines whether OpenGL is available on iOS/macOS.
+  rtc_use_opengl_rendering = !(is_ios && target_environment == "catalyst")
 
   # When set to false, builtin audio encoder/decoder factories and all the
   # audio codecs they depend on will not be included in libwebrtc.{a|lib}

--- a/webrtc.gni
+++ b/webrtc.gni
@@ -958,10 +958,15 @@ if (is_ios) {
       deps = [ ":create_bracket_include_headers_$this_target_name" ]
     }
 
+    if (target_environment == "catalyst") {
+      headers_dir = "Versions/A/Headers"
+    } else {
+      headers_dir = "Headers"
+    }
     copy("copy_umbrella_header_$target_name") {
       sources = [ umbrella_header_path ]
       outputs =
-          [ "$root_out_dir/$output_name.framework/Headers/$output_name.h" ]
+          [ "$root_out_dir/$output_name.framework/$headers_dir/$output_name.h" ]
 
       deps = [ ":umbrella_header_$target_name" ]
     }

--- a/webrtc.gni
+++ b/webrtc.gni
@@ -291,7 +291,7 @@ declare_args() {
 
 # Make it possible to provide custom locations for some libraries (move these
 # up into declare_args should we need to actually use them for the GN build).
-rtc_libvpx_dir = "//third_party/libvpx"
+rtc_libvpx_dir = "//ringrtc_overrides/libvpx"
 rtc_opus_dir = "//third_party/opus"
 
 # Desktop capturer is supported only on Windows, OSX and Linux.


### PR DESCRIPTION
…with the caveat that it may not *work* on Catalyst yet. This is just getting it building for now, since upstream Catalyst support [is still scant](https://bugs.chromium.org/p/webrtc/issues/detail?id=11516).

~~There is one missing change here to get libvpx to build on Catalyst as well, but libvpx comes from the separate `third_party` repo. We'll have to decide how to handle that.~~ Fixed!