### PR TITLE
Fix for arm64 Windows builds

### DIFF
--- a/ringrtc_overrides/libvpx/BUILD.gn
+++ b/ringrtc_overrides/libvpx/BUILD.gn
@@ -37,7 +37,7 @@ if (current_cpu == "x86") {
     cpu_arch_full = "arm"
   }
 } else if (current_cpu == "arm64") {
-  if (is_chromeos_ash || is_win || is_mac || (is_ios && target_environment == "catalyst")) {
+  if (is_chromeos_ash || is_mac || (is_ios && target_environment == "catalyst")) {
     cpu_arch_full = "arm64-highbd"
   } else {
     cpu_arch_full = current_cpu

--- a/ringrtc_overrides/libvpx/BUILD.gn
+++ b/ringrtc_overrides/libvpx/BUILD.gn
@@ -339,7 +339,7 @@ static_library("libvpx") {
       sources = libvpx_srcs_arm
     }
   } else if (current_cpu == "arm64") {
-    if (cpu_arch_full == "arm64-highbd") {
+    if (cpu_arch_full == "arm64-highbd" || is_win) {
       sources = libvpx_srcs_arm64_highbd
     } else {
       sources = libvpx_srcs_arm64


### PR DESCRIPTION
The arm64 Windows build is currently broken with the following error:

```
../../src/webrtc/src/third_party/libvpx/source/libvpx/vp8/common/dequantize.c(11,10): fatal error: 'vpx_config.h' file not found
#include "vpx_config.h"
         ^~~~~~~~~~~~~~
1 error generated.
```

This commit is based on https://groups.google.com/a/chromium.org/g/feature-media-reviews/c/tFt_fG2RkFw, which indicates that arm64 Windows was incorrectly identified as `arm64-highbd` instead of `arm64` (for which a config folder exists). This fixes the arm64 Windows build