### PR TITLE
Upstream changes for AsyncResolver

### DIFF
--- a/modules/audio_device/dummy/file_audio_device.cc
+++ b/modules/audio_device/dummy/file_audio_device.cc
@@ -218,7 +218,7 @@ int32_t FileAudioDevice::StartPlayout() {
 
   _ptrThreadPlay.reset(new rtc::PlatformThread(
       PlayThreadFunc, this, "webrtc_audio_module_play_thread",
-      rtc::kRealtimePriority));
+      rtc::ThreadAttributes().SetPriority(rtc::kLowPriority)));
   _ptrThreadPlay->Start();
 
   RTC_LOG(LS_INFO) << "Started playout capture to output file: "
@@ -278,7 +278,7 @@ int32_t FileAudioDevice::StartRecording() {
 
   _ptrThreadRec.reset(new rtc::PlatformThread(
       RecThreadFunc, this, "webrtc_audio_module_capture_thread",
-      rtc::kRealtimePriority));
+      rtc::ThreadAttributes().SetPriority(rtc::kLowPriority)));
 
   _ptrThreadRec->Start();
 

--- a/rtc_base/event_tracer.cc
+++ b/rtc_base/event_tracer.cc
@@ -91,7 +91,7 @@ class EventLogger final {
       : logging_thread_(EventTracingThreadFunc,
                         this,
                         "EventTracingThread",
-                        kLowPriority) {}
+                        ThreadAttributes().SetPriority(kLowPriority)) {}
   ~EventLogger() { RTC_DCHECK(thread_checker_.IsCurrent()); }
 
   void AddTraceEvent(const char* name,

--- a/rtc_base/net_helpers.cc
+++ b/rtc_base/net_helpers.cc
@@ -8,7 +8,15 @@
  *  be found in the AUTHORS file in the root of the source tree.
  */
 
+#include <memory>
+#include <string>
+#include <utility>
+
 #include "rtc_base/net_helpers.h"
+
+#include "api/ref_counted_base.h"
+#include "rtc_base/synchronization/mutex.h"
+#include "rtc_base/thread_annotations.h"
 
 #if defined(WEBRTC_WIN)
 #include <ws2spi.h>
@@ -25,7 +33,9 @@
 #endif  // defined(WEBRTC_POSIX) && !defined(__native_client__)
 
 #include "api/task_queue/task_queue_base.h"
+#include "rtc_base/ip_address.h"
 #include "rtc_base/logging.h"
+#include "rtc_base/platform_thread.h"
 #include "rtc_base/signal_thread.h"
 #include "rtc_base/task_queue.h"
 #include "rtc_base/task_utils/to_queued_task.h"
@@ -84,30 +94,67 @@ int ResolveHostname(const std::string& hostname,
 #endif  // !__native_client__
 }
 
-AsyncResolver::AsyncResolver() : error_(-1) {}
+struct AsyncResolver::State : public RefCountedBase {
+  webrtc::Mutex mutex;
+  enum class Status {
+    kLive,
+    kDead
+  } status RTC_GUARDED_BY(mutex) = Status::kLive;
+};
+
+AsyncResolver::AsyncResolver() : error_(-1), state_(new State) {}
 
 AsyncResolver::~AsyncResolver() {
   RTC_DCHECK_RUN_ON(&sequence_checker_);
+
+  // Ensure the thread isn't using a stale reference to the current task queue,
+  // or calling into ResolveDone post destruction.
+  webrtc::MutexLock lock(&state_->mutex);
+  state_->status = State::Status::kDead;
+}
+
+void RunResolution(void* obj) {
+  std::function<void()>* function_ptr =
+      static_cast<std::function<void()>*>(obj);
+  (*function_ptr)();
+  delete function_ptr;
 }
 
 void AsyncResolver::Start(const SocketAddress& addr) {
   RTC_DCHECK_RUN_ON(&sequence_checker_);
   RTC_DCHECK(!destroy_called_);
   addr_ = addr;
-  webrtc::TaskQueueBase* current_task_queue = webrtc::TaskQueueBase::Current();
-  popup_thread_ = Thread::Create();
-  popup_thread_->Start();
-  popup_thread_->PostTask(webrtc::ToQueuedTask(
-      [this, flag = safety_.flag(), addr, current_task_queue] {
+  auto thread_function =
+      [this, addr, caller_task_queue = webrtc::TaskQueueBase::Current(),
+       state = state_] {
         std::vector<IPAddress> addresses;
         int error =
             ResolveHostname(addr.hostname().c_str(), addr.family(), &addresses);
-        current_task_queue->PostTask(webrtc::ToQueuedTask(
-            std::move(flag), [this, error, addresses = std::move(addresses)] {
-              RTC_DCHECK_RUN_ON(&sequence_checker_);
-              ResolveDone(std::move(addresses), error);
-            }));
-      }));
+        webrtc::MutexLock lock(&state->mutex);
+        if (state->status == State::Status::kLive) {
+          caller_task_queue->PostTask(webrtc::ToQueuedTask(
+              [this, error, addresses = std::move(addresses), state] {
+                bool live;
+                {
+                  // ResolveDone can lead to instance destruction, so make sure
+                  // we don't deadlock.
+                  webrtc::MutexLock lock(&state->mutex);
+                  live = state->status == State::Status::kLive;
+                }
+                if (live) {
+                  RTC_DCHECK_RUN_ON(&sequence_checker_);
+                  ResolveDone(std::move(addresses), error);
+                }
+              }));
+        }
+      };
+  PlatformThread thread(RunResolution,
+                        new std::function<void()>(std::move(thread_function)),
+                        "NameResolution", ThreadAttributes().SetDetached());
+  thread.Start();
+  // Although |thread| is detached, the PlatformThread contract mandates to call
+  // Stop() before destruction. The call doesn't actually stop anything.
+  thread.Stop();
 }
 
 bool AsyncResolver::GetResolvedAddress(int family, SocketAddress* addr) const {

--- a/rtc_base/net_helpers.h
+++ b/rtc_base/net_helpers.h
@@ -51,6 +51,9 @@ class RTC_EXPORT AsyncResolver : public AsyncResolverInterface {
   const std::vector<IPAddress>& addresses() const;
 
  private:
+  // Fwd decl.
+  struct State;
+
   void ResolveDone(std::vector<IPAddress> addresses, int error)
       RTC_EXCLUSIVE_LOCKS_REQUIRED(sequence_checker_);
   void MaybeSelfDestruct();
@@ -58,11 +61,12 @@ class RTC_EXPORT AsyncResolver : public AsyncResolverInterface {
   SocketAddress addr_ RTC_GUARDED_BY(sequence_checker_);
   std::vector<IPAddress> addresses_ RTC_GUARDED_BY(sequence_checker_);
   int error_ RTC_GUARDED_BY(sequence_checker_);
-  webrtc::ScopedTaskSafety safety_ RTC_GUARDED_BY(sequence_checker_);
-  std::unique_ptr<Thread> popup_thread_ RTC_GUARDED_BY(sequence_checker_);
+//   webrtc::ScopedTaskSafety safety_ RTC_GUARDED_BY(sequence_checker_);
+//   std::unique_ptr<Thread> popup_thread_ RTC_GUARDED_BY(sequence_checker_);
   bool recursion_check_ =
       false;  // Protects against SignalDone calling into Destroy.
   bool destroy_called_ = false;
+  scoped_refptr<State> state_;
   RTC_NO_UNIQUE_ADDRESS webrtc::SequenceChecker sequence_checker_;
 };
 

--- a/rtc_base/platform_thread.cc
+++ b/rtc_base/platform_thread.cc
@@ -10,6 +10,8 @@
 
 #include "rtc_base/platform_thread.h"
 
+#include <memory>
+
 #if !defined(WEBRTC_WIN)
 #include <sched.h>
 #endif
@@ -18,123 +20,22 @@
 
 #include <algorithm>
 
+#include "absl/memory/memory.h"
 #include "rtc_base/checks.h"
 
 namespace rtc {
+
 namespace {
-#if !defined(WEBRTC_WIN)
-struct ThreadAttributes {
-  ThreadAttributes() { pthread_attr_init(&attr); }
-  ~ThreadAttributes() { pthread_attr_destroy(&attr); }
-  pthread_attr_t* operator&() { return &attr; }
-  pthread_attr_t attr;
+struct ThreadStartData {
+  ThreadRunFunction run_function;
+  void* obj;
+  std::string thread_name;
+  ThreadPriority priority;
 };
-#endif  // defined(WEBRTC_WIN)
-}  // namespace
 
-PlatformThread::PlatformThread(ThreadRunFunction func,
-                               void* obj,
-                               absl::string_view thread_name,
-                               ThreadPriority priority /*= kNormalPriority*/)
-    : run_function_(func), priority_(priority), obj_(obj), name_(thread_name) {
-  RTC_DCHECK(func);
-  RTC_DCHECK(!name_.empty());
-  // TODO(tommi): Consider lowering the limit to 15 (limit on Linux).
-  RTC_DCHECK(name_.length() < 64);
-  spawned_thread_checker_.Detach();
-}
-
-PlatformThread::~PlatformThread() {
-  RTC_DCHECK(thread_checker_.IsCurrent());
+bool SetPriority(ThreadPriority priority) {
 #if defined(WEBRTC_WIN)
-  RTC_DCHECK(!thread_);
-  RTC_DCHECK(!thread_id_);
-#endif  // defined(WEBRTC_WIN)
-}
-
-#if defined(WEBRTC_WIN)
-DWORD WINAPI PlatformThread::StartThread(void* param) {
-  // The GetLastError() function only returns valid results when it is called
-  // after a Win32 API function that returns a "failed" result. A crash dump
-  // contains the result from GetLastError() and to make sure it does not
-  // falsely report a Windows error we call SetLastError here.
-  ::SetLastError(ERROR_SUCCESS);
-  static_cast<PlatformThread*>(param)->Run();
-  return 0;
-}
-#else
-void* PlatformThread::StartThread(void* param) {
-  static_cast<PlatformThread*>(param)->Run();
-  return 0;
-}
-#endif  // defined(WEBRTC_WIN)
-
-void PlatformThread::Start() {
-  RTC_DCHECK(thread_checker_.IsCurrent());
-  RTC_DCHECK(!thread_) << "Thread already started?";
-#if defined(WEBRTC_WIN)
-  // See bug 2902 for background on STACK_SIZE_PARAM_IS_A_RESERVATION.
-  // Set the reserved stack stack size to 1M, which is the default on Windows
-  // and Linux.
-  thread_ = ::CreateThread(nullptr, 1024 * 1024, &StartThread, this,
-                           STACK_SIZE_PARAM_IS_A_RESERVATION, &thread_id_);
-  RTC_CHECK(thread_) << "CreateThread failed";
-  RTC_DCHECK(thread_id_);
-#else
-  ThreadAttributes attr;
-  // Set the stack stack size to 1M.
-  pthread_attr_setstacksize(&attr, 1024 * 1024);
-  RTC_CHECK_EQ(0, pthread_create(&thread_, &attr, &StartThread, this));
-#endif  // defined(WEBRTC_WIN)
-}
-
-bool PlatformThread::IsRunning() const {
-  RTC_DCHECK(thread_checker_.IsCurrent());
-#if defined(WEBRTC_WIN)
-  return thread_ != nullptr;
-#else
-  return thread_ != 0;
-#endif  // defined(WEBRTC_WIN)
-}
-
-PlatformThreadRef PlatformThread::GetThreadRef() const {
-#if defined(WEBRTC_WIN)
-  return thread_id_;
-#else
-  return thread_;
-#endif  // defined(WEBRTC_WIN)
-}
-
-void PlatformThread::Stop() {
-  RTC_DCHECK(thread_checker_.IsCurrent());
-  if (!IsRunning())
-    return;
-
-#if defined(WEBRTC_WIN)
-  WaitForSingleObject(thread_, INFINITE);
-  CloseHandle(thread_);
-  thread_ = nullptr;
-  thread_id_ = 0;
-#else
-  RTC_CHECK_EQ(0, pthread_join(thread_, nullptr));
-  thread_ = 0;
-#endif  // defined(WEBRTC_WIN)
-  spawned_thread_checker_.Detach();
-}
-
-void PlatformThread::Run() {
-  // Attach the worker thread checker to this thread.
-  RTC_DCHECK(spawned_thread_checker_.IsCurrent());
-  rtc::SetCurrentThreadName(name_.c_str());
-  SetPriority(priority_);
-  run_function_(obj_);
-}
-
-bool PlatformThread::SetPriority(ThreadPriority priority) {
-  RTC_DCHECK(spawned_thread_checker_.IsCurrent());
-
-#if defined(WEBRTC_WIN)
-  return SetThreadPriority(thread_, priority) != FALSE;
+  return SetThreadPriority(GetCurrentThread(), priority) != FALSE;
 #elif defined(__native_client__) || defined(WEBRTC_FUCHSIA)
   // Setting thread priorities is not supported in NaCl or Fuchsia.
   return true;
@@ -176,13 +77,124 @@ bool PlatformThread::SetPriority(ThreadPriority priority) {
       param.sched_priority = top_prio;
       break;
   }
-  return pthread_setschedparam(thread_, policy, &param) == 0;
+  return pthread_setschedparam(pthread_self(), policy, &param) == 0;
+#endif  // defined(WEBRTC_WIN)
+}
+
+void RunPlatformThread(std::unique_ptr<ThreadStartData> data) {
+  rtc::SetCurrentThreadName(data->thread_name.c_str());
+  data->thread_name.clear();
+  SetPriority(data->priority);
+  data->run_function(data->obj);
+}
+
+#if defined(WEBRTC_WIN)
+DWORD WINAPI StartThread(void* param) {
+  // The GetLastError() function only returns valid results when it is called
+  // after a Win32 API function that returns a "failed" result. A crash dump
+  // contains the result from GetLastError() and to make sure it does not
+  // falsely report a Windows error we call SetLastError here.
+  ::SetLastError(ERROR_SUCCESS);
+  RunPlatformThread(absl::WrapUnique(static_cast<ThreadStartData*>(param)));
+  return 0;
+}
+#else
+void* StartThread(void* param) {
+  RunPlatformThread(absl::WrapUnique(static_cast<ThreadStartData*>(param)));
+  return 0;
+}
+#endif  // defined(WEBRTC_WIN)
+
+}  // namespace
+
+PlatformThread::PlatformThread(ThreadRunFunction func,
+                               void* obj,
+                               absl::string_view thread_name,
+                               ThreadAttributes attributes)
+    : run_function_(func),
+      attributes_(attributes),
+      obj_(obj),
+      name_(thread_name) {
+  RTC_DCHECK(func);
+  RTC_DCHECK(!name_.empty());
+  // TODO(tommi): Consider lowering the limit to 15 (limit on Linux).
+  RTC_DCHECK(name_.length() < 64);
+}
+
+PlatformThread::~PlatformThread() {
+  RTC_DCHECK_RUN_ON(&thread_checker_);
+  RTC_DCHECK(!thread_);
+#if defined(WEBRTC_WIN)
+  RTC_DCHECK(!thread_id_);
+#endif  // defined(WEBRTC_WIN)
+}
+
+void PlatformThread::Start() {
+  RTC_DCHECK_RUN_ON(&thread_checker_);
+  RTC_DCHECK(!thread_) << "Thread already started?";
+  ThreadStartData* data =
+      new ThreadStartData{run_function_, obj_, name_, attributes_.priority};
+#if defined(WEBRTC_WIN)
+  // See bug 2902 for background on STACK_SIZE_PARAM_IS_A_RESERVATION.
+  // Set the reserved stack stack size to 1M, which is the default on Windows
+  // and Linux.
+  thread_ = ::CreateThread(nullptr, 1024 * 1024, &StartThread, data,
+                           STACK_SIZE_PARAM_IS_A_RESERVATION, &thread_id_);
+  RTC_CHECK(thread_) << "CreateThread failed";
+  RTC_DCHECK(thread_id_);
+#else
+  pthread_attr_t attr;
+  pthread_attr_init(&attr);
+  // Set the stack stack size to 1M.
+  pthread_attr_setstacksize(&attr, 1024 * 1024);
+  pthread_attr_setdetachstate(&attr, attributes_.joinable
+                                         ? PTHREAD_CREATE_JOINABLE
+                                         : PTHREAD_CREATE_DETACHED);
+  RTC_CHECK_EQ(0, pthread_create(&thread_, &attr, &StartThread, data));
+  pthread_attr_destroy(&attr);
+#endif  // defined(WEBRTC_WIN)
+}
+
+bool PlatformThread::IsRunning() const {
+  RTC_DCHECK_RUN_ON(&thread_checker_);
+#if defined(WEBRTC_WIN)
+  return thread_ != nullptr;
+#else
+  return thread_ != 0;
+#endif  // defined(WEBRTC_WIN)
+}
+
+PlatformThreadRef PlatformThread::GetThreadRef() const {
+#if defined(WEBRTC_WIN)
+  return thread_id_;
+#else
+  return thread_;
+#endif  // defined(WEBRTC_WIN)
+}
+
+void PlatformThread::Stop() {
+  RTC_DCHECK_RUN_ON(&thread_checker_);
+  if (!IsRunning())
+    return;
+
+#if defined(WEBRTC_WIN)
+  if (attributes_.joinable) {
+    WaitForSingleObject(thread_, INFINITE);
+  }
+  CloseHandle(thread_);
+  thread_ = nullptr;
+  thread_id_ = 0;
+#else
+  if (attributes_.joinable) {
+    RTC_CHECK_EQ(0, pthread_join(thread_, nullptr));
+  }
+  thread_ = 0;
 #endif  // defined(WEBRTC_WIN)
 }
 
 #if defined(WEBRTC_WIN)
 bool PlatformThread::QueueAPC(PAPCFUNC function, ULONG_PTR data) {
-  RTC_DCHECK(thread_checker_.IsCurrent());
+  RTC_DCHECK_RUN_ON(&thread_checker_);
   RTC_DCHECK(IsRunning());
 
   return QueueUserAPC(function, thread_, data) != FALSE;

--- a/rtc_base/platform_thread.h
+++ b/rtc_base/platform_thread.h
@@ -17,9 +17,9 @@
 #include <string>
 
 #include "absl/strings/string_view.h"
+#include "rtc_base/synchronization/sequence_checker.h"
 #include "rtc_base/constructor_magic.h"
 #include "rtc_base/platform_thread_types.h"
-#include "rtc_base/thread_checker.h"
 
 namespace rtc {
 
@@ -42,6 +42,20 @@ enum ThreadPriority {
 #endif
 };
 
+struct ThreadAttributes {
+  ThreadPriority priority = kNormalPriority;
+  bool joinable = true;
+
+  ThreadAttributes& SetPriority(ThreadPriority priority_param) {
+    priority = priority_param;
+    return *this;
+  }
+  ThreadAttributes& SetDetached() {
+    joinable = false;
+    return *this;
+  }
+};
+
 // Represents a simple worker thread.  The implementation must be assumed
 // to be single threaded, meaning that all methods of the class, must be
 // called from the same thread, including instantiation.
@@ -50,13 +64,14 @@ class PlatformThread {
   PlatformThread(ThreadRunFunction func,
                  void* obj,
                  absl::string_view thread_name,
-                 ThreadPriority priority = kNormalPriority);
+                 ThreadAttributes attributes = ThreadAttributes());
   virtual ~PlatformThread();
 
   const std::string& name() const { return name_; }
 
   // Spawns a thread and tries to set thread priority according to the priority
   // from when CreateThread was called.
+  // Start can only be called after the constructor or after a call to Stop().
   void Start();
 
   bool IsRunning() const;
@@ -65,7 +80,11 @@ class PlatformThread {
   // thread checks.
   PlatformThreadRef GetThreadRef() const;
 
-  // Stops (joins) the spawned thread.
+  // Stop() prepares the PlatformThread for destruction or another call to
+  // Start(). For a PlatformThread that's been created with
+  // ThreadAttributes::joinable true (the default), Stop() suspends the calling
+  // thread until the created thread exits unless the thread has already exited.
+  // Stop() can only be called after calling Start().
   void Stop();
 
  protected:
@@ -75,25 +94,17 @@ class PlatformThread {
 #endif
 
  private:
-  void Run();
-  bool SetPriority(ThreadPriority priority);
-
   ThreadRunFunction const run_function_ = nullptr;
-  const ThreadPriority priority_ = kNormalPriority;
+  const ThreadAttributes attributes_;
   void* const obj_;
   // TODO(pbos): Make sure call sites use string literals and update to a const
   // char* instead of a std::string.
   const std::string name_;
-  rtc::ThreadChecker thread_checker_;
-  rtc::ThreadChecker spawned_thread_checker_;
+  webrtc::SequenceChecker thread_checker_;
 #if defined(WEBRTC_WIN)
-  static DWORD WINAPI StartThread(void* param);
-
   HANDLE thread_ = nullptr;
   DWORD thread_id_ = 0;
 #else
-  static void* StartThread(void* param);
-
   pthread_t thread_ = 0;
 #endif  // defined(WEBRTC_WIN)
   RTC_DISALLOW_COPY_AND_ASSIGN(PlatformThread);

--- a/rtc_base/task_queue_libevent.cc
+++ b/rtc_base/task_queue_libevent.cc
@@ -173,7 +173,7 @@ class TaskQueueLibevent::SetTimerTask : public QueuedTask {
 TaskQueueLibevent::TaskQueueLibevent(absl::string_view queue_name,
                                      rtc::ThreadPriority priority)
     : event_base_(event_base_new()),
-      thread_(&TaskQueueLibevent::ThreadMain, this, queue_name, priority) {
+      thread_(&TaskQueueLibevent::ThreadMain, this, queue_name, rtc::ThreadAttributes().SetPriority(priority)) {
   int fds[2];
   RTC_CHECK(pipe(fds) == 0);
   SetNonBlocking(fds[0]);


### PR DESCRIPTION
Reference: https://source.chromium.org/chromium/_/webrtc/src.git/+/1366b0f841c84d842e3ff5ab9050c2b39a96c2f2

For every TURN server URI name being resolved, a dedicated thread was being created for it. This patch applies the changes to the AsyncResolver to help fix the issue. Now the PlatformThread is used for these DNS lookups.

On any platform, several threads were being allocated (possibly TURN server count * Network Interface count).

On iOS, the threads were remaining active even after peer connection resources were closed. On Android, they seemed to be terminated properly, although the number of threads during the call establishment phase was fairly high.

With this fix, the thread count is minimal.