### PR TITLE
Initialize Playout if Starting when Setting

### DIFF
--- a/audio/audio_state.cc
+++ b/audio/audio_state.cc
@@ -130,6 +130,8 @@ void AudioState::SetPlayout(bool enabled) {
     if (enabled) {
       UpdateNullAudioPollerState();
       if (!receiving_streams_.empty()) {
+        // WebRTC change to ensure the ADM is initialized before attempting
+        // to start playout (preventing a crash on some ADMs).
         if (config_.audio_device_module->InitPlayout() == 0) {
           config_.audio_device_module->StartPlayout();
         } else {

--- a/audio/audio_state.cc
+++ b/audio/audio_state.cc
@@ -130,7 +130,11 @@ void AudioState::SetPlayout(bool enabled) {
     if (enabled) {
       UpdateNullAudioPollerState();
       if (!receiving_streams_.empty()) {
-        config_.audio_device_module->StartPlayout();
+        if (config_.audio_device_module->InitPlayout() == 0) {
+          config_.audio_device_module->StartPlayout();
+        } else {
+          RTC_DLOG_F(LS_ERROR) << "Failed to initialize playout.";
+        }
       }
     } else {
       config_.audio_device_module->StopPlayout();


### PR DESCRIPTION
We are now using the SetAudioPlayout() API to control when playout starts. In some cases, such as when sharing ADMs, audio gets stopped and therefore deinitialized. This ensures that it is initialized before starting it, otherwise some ADMs (such as the iOS one) will crash.