### PR TITLE
Make it possible to share an APM between PeerConnections

### DIFF
--- a/audio/audio_state.cc
+++ b/audio/audio_state.cc
@@ -130,7 +130,7 @@ void AudioState::SetPlayout(bool enabled) {
     if (enabled) {
       UpdateNullAudioPollerState();
       if (!receiving_streams_.empty()) {
-        // WebRTC change to ensure the ADM is initialized before attempting
+        // RingRTC change to ensure the ADM is initialized before attempting
         // to start playout (preventing a crash on some ADMs).
         if (config_.audio_device_module->InitPlayout() == 0) {
           config_.audio_device_module->StartPlayout();

--- a/media/engine/webrtc_voice_engine.cc
+++ b/media/engine/webrtc_voice_engine.cc
@@ -2287,7 +2287,6 @@ void WebRtcVoiceMediaChannel::OnNetworkRouteChanged(
 
 bool WebRtcVoiceMediaChannel::MuteStream(uint32_t ssrc, bool muted) {
   RTC_DCHECK_RUN_ON(worker_thread_);
-
   const auto it = send_streams_.find(ssrc);
   if (it == send_streams_.end()) {
     RTC_LOG(LS_WARNING) << "The specified ssrc " << ssrc << " is not in use.";
@@ -2300,6 +2299,8 @@ bool WebRtcVoiceMediaChannel::MuteStream(uint32_t ssrc, bool muted) {
   // This implementation is not ideal, instead we should signal the AGC when
   // the mic channel is muted/unmuted. We can't do it today because there
   // is no good way to know which stream is mapping to the mic channel.
+  // RingRTC change to RingRTC change to make it possible to share an APM.
+  // See set_capture_output_used in audio_processing.h.
   bool capture_output_used = false;
   for (const auto& kv : send_streams_) {
     capture_output_used = capture_output_used || !kv.second->muted();

--- a/media/engine/webrtc_voice_engine_unittest.cc
+++ b/media/engine/webrtc_voice_engine_unittest.cc
@@ -255,7 +255,7 @@ class WebRtcVoiceEngineTestFake : public ::testing::TestWithParam<bool> {
       return false;
     }
     if (!use_null_apm_) {
-      EXPECT_CALL(*apm_, set_output_will_be_muted(false));
+      EXPECT_CALL(*apm_, set_capture_output_used(nullptr, true));
     }
     return channel_->SetAudioSend(kSsrcX, true, nullptr, &fake_source_);
   }
@@ -323,7 +323,7 @@ class WebRtcVoiceEngineTestFake : public ::testing::TestWithParam<bool> {
                     const cricket::AudioOptions* options = nullptr) {
     ASSERT_TRUE(channel_);
     if (!use_null_apm_) {
-      EXPECT_CALL(*apm_, set_output_will_be_muted(!enable));
+      EXPECT_CALL(*apm_, set_capture_output_used(nullptr, enable));
     }
     EXPECT_TRUE(channel_->SetAudioSend(ssrc, enable, options, source));
   }

--- a/media/engine/webrtc_voice_engine_unittest.cc
+++ b/media/engine/webrtc_voice_engine_unittest.cc
@@ -255,6 +255,8 @@ class WebRtcVoiceEngineTestFake : public ::testing::TestWithParam<bool> {
       return false;
     }
     if (!use_null_apm_) {
+      // RingRTC change to RingRTC change to make it possible to share an APM.
+      // See set_capture_output_used in audio_processing.h.
       EXPECT_CALL(*apm_, set_capture_output_used(nullptr, true));
     }
     return channel_->SetAudioSend(kSsrcX, true, nullptr, &fake_source_);
@@ -323,6 +325,8 @@ class WebRtcVoiceEngineTestFake : public ::testing::TestWithParam<bool> {
                     const cricket::AudioOptions* options = nullptr) {
     ASSERT_TRUE(channel_);
     if (!use_null_apm_) {
+      // RingRTC change to RingRTC change to make it possible to share an APM.
+      // See set_capture_output_used in audio_processing.h.
       EXPECT_CALL(*apm_, set_capture_output_used(nullptr, enable));
     }
     EXPECT_TRUE(channel_->SetAudioSend(ssrc, enable, options, source));

--- a/modules/audio_processing/audio_processing_impl.cc
+++ b/modules/audio_processing/audio_processing_impl.cc
@@ -675,9 +675,15 @@ size_t AudioProcessingImpl::num_output_channels() const {
   return formats_.api_format.output_stream().num_channels();
 }
 
-void AudioProcessingImpl::set_output_will_be_muted(bool muted) {
+void AudioProcessingImpl::set_capture_output_used(void* user, bool used) {
   MutexLock lock(&mutex_capture_);
-  HandleCaptureOutputUsedSetting(!muted);
+  if (used) {
+    capture_output_users_.insert(user);
+  } else {
+    capture_output_users_.erase(user);
+  }
+  bool capture_output_used = !capture_output_users_.empty();
+  HandleCaptureOutputUsedSetting(capture_output_used);
 }
 
 void AudioProcessingImpl::HandleCaptureOutputUsedSetting(

--- a/modules/audio_processing/audio_processing_impl.h
+++ b/modules/audio_processing/audio_processing_impl.h
@@ -15,6 +15,7 @@
 
 #include <list>
 #include <memory>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -97,7 +98,7 @@ class AudioProcessingImpl : public AudioProcessing {
                     float* const* dest) override;
   bool GetLinearAecOutput(
       rtc::ArrayView<std::array<float, 160>> linear_output) const override;
-  void set_output_will_be_muted(bool muted) override;
+  void set_capture_output_used(void* user, bool muted) override;
   void HandleCaptureOutputUsedSetting(bool capture_output_used)
       RTC_EXCLUSIVE_LOCKS_REQUIRED(mutex_capture_);
   int set_stream_delay_ms(int delay) override;
@@ -530,6 +531,11 @@ class AudioProcessingImpl : public AudioProcessing {
   RmsLevel capture_input_rms_ RTC_GUARDED_BY(mutex_capture_);
   RmsLevel capture_output_rms_ RTC_GUARDED_BY(mutex_capture_);
   int capture_rms_interval_counter_ RTC_GUARDED_BY(mutex_capture_) = 0;
+
+  // Each "user" (could be anything) has a separate state of whether or not
+  // it's using the capture output, and if there are any users capturing,
+  // we enable processing.
+  std::set<void*> capture_output_users_ RTC_GUARDED_BY(mutex_capture_);
 
   // Lock protection not needed.
   std::unique_ptr<

--- a/modules/audio_processing/audio_processing_impl.h
+++ b/modules/audio_processing/audio_processing_impl.h
@@ -98,6 +98,8 @@ class AudioProcessingImpl : public AudioProcessing {
                     float* const* dest) override;
   bool GetLinearAecOutput(
       rtc::ArrayView<std::array<float, 160>> linear_output) const override;
+  // RingRTC change to RingRTC change to make it possible to share an APM.
+  // See set_capture_output_used in audio_processing.h.
   void set_capture_output_used(void* user, bool muted) override;
   void HandleCaptureOutputUsedSetting(bool capture_output_used)
       RTC_EXCLUSIVE_LOCKS_REQUIRED(mutex_capture_);
@@ -532,6 +534,8 @@ class AudioProcessingImpl : public AudioProcessing {
   RmsLevel capture_output_rms_ RTC_GUARDED_BY(mutex_capture_);
   int capture_rms_interval_counter_ RTC_GUARDED_BY(mutex_capture_) = 0;
 
+  // RingRTC change to RingRTC change to make it possible to share an APM.
+  // See set_capture_output_used in audio_processing.h.
   // Each "user" (could be anything) has a separate state of whether or not
   // it's using the capture output, and if there are any users capturing,
   // we enable processing.

--- a/modules/audio_processing/include/audio_processing.h
+++ b/modules/audio_processing/include/audio_processing.h
@@ -601,6 +601,12 @@ class RTC_EXPORT AudioProcessing : public rtc::RefCountInterface {
   virtual size_t num_output_channels() const = 0;
   virtual size_t num_reverse_channels() const = 0;
 
+  // Set to true when the output of AudioProcessing will be muted or in some
+  // other way not used. Ideally, the captured audio would still be processed,
+  // but some components may change behavior based on this information.
+  // Default false. This method takes a lock. To achieve this in a lock-less
+  // manner the PostRuntimeSetting can instead be used.
+  //
   // RingRTC change to make it possible to share an APM (and thus, WebRtcVoiceEngine)
   // between PeerConnections created from the same PeerConnectionFactory.
   // Without this change, the code has a "last user wins" behavior,
@@ -610,12 +616,6 @@ class RTC_EXPORT AudioProcessing : public rtc::RefCountInterface {
   // captured output after the used PeerConnection signals that it is using
   // captured output.  In that case, the call will end up
   // without APM processing, which means it will have noise and echo.
-  //
-  // Set to true when the output of AudioProcessing will be muted or in some
-  // other way not used. Ideally, the captured audio would still be processed,
-  // but some components may change behavior based on this information.
-  // Default false. This method takes a lock. To achieve this in a lock-less
-  // manner the PostRuntimeSetting can instead be used.
   virtual void set_capture_output_used(void* user, bool muted) = 0;
 
   // Enqueues a runtime setting.

--- a/modules/audio_processing/include/audio_processing.h
+++ b/modules/audio_processing/include/audio_processing.h
@@ -601,12 +601,22 @@ class RTC_EXPORT AudioProcessing : public rtc::RefCountInterface {
   virtual size_t num_output_channels() const = 0;
   virtual size_t num_reverse_channels() const = 0;
 
+  // RingRTC change to make it possible to share an APM (and thus, WebRtcVoiceEngine)
+  // between PeerConnections created from the same PeerConnectionFactory.
+  // Without this change, the code has a "last user wins" behavior,
+  // which breaks when creating multiple PeerConnections from the
+  // same PeerConnectionFactory.  In particular, this happens when using
+  // ICE forking and the unused PeerConnections signal they are not using
+  // captured output after the used PeerConnection signals that it is using
+  // captured output.  In that case, the call will end up
+  // without APM processing, which means it will have noise and echo.
+  //
   // Set to true when the output of AudioProcessing will be muted or in some
   // other way not used. Ideally, the captured audio would still be processed,
   // but some components may change behavior based on this information.
   // Default false. This method takes a lock. To achieve this in a lock-less
   // manner the PostRuntimeSetting can instead be used.
-  virtual void set_output_will_be_muted(bool muted) = 0;
+  virtual void set_capture_output_used(void* user, bool muted) = 0;
 
   // Enqueues a runtime setting.
   virtual void SetRuntimeSetting(RuntimeSetting setting) = 0;

--- a/modules/audio_processing/include/mock_audio_processing.h
+++ b/modules/audio_processing/include/mock_audio_processing.h
@@ -94,6 +94,8 @@ class MockAudioProcessing : public AudioProcessing {
   MOCK_METHOD(size_t, num_proc_channels, (), (const, override));
   MOCK_METHOD(size_t, num_output_channels, (), (const, override));
   MOCK_METHOD(size_t, num_reverse_channels, (), (const, override));
+  // RingRTC change to RingRTC change to make it possible to share an APM.
+  // See set_capture_output_used in audio_processing.h.
   MOCK_METHOD(void, set_capture_output_used, (void* user, bool muted), (override));
   MOCK_METHOD(void, SetRuntimeSetting, (RuntimeSetting setting), (override));
   MOCK_METHOD(bool, PostRuntimeSetting, (RuntimeSetting setting), (override));

--- a/modules/audio_processing/include/mock_audio_processing.h
+++ b/modules/audio_processing/include/mock_audio_processing.h
@@ -94,7 +94,7 @@ class MockAudioProcessing : public AudioProcessing {
   MOCK_METHOD(size_t, num_proc_channels, (), (const, override));
   MOCK_METHOD(size_t, num_output_channels, (), (const, override));
   MOCK_METHOD(size_t, num_reverse_channels, (), (const, override));
-  MOCK_METHOD(void, set_output_will_be_muted, (bool muted), (override));
+  MOCK_METHOD(void, set_capture_output_used, (void* user, bool muted), (override));
   MOCK_METHOD(void, SetRuntimeSetting, (RuntimeSetting setting), (override));
   MOCK_METHOD(bool, PostRuntimeSetting, (RuntimeSetting setting), (override));
   MOCK_METHOD(int,


### PR DESCRIPTION
This fixes a bug where calls with ICE forking are not getting AEC and noise suppression.

Without this change, the code has a "last user wins" behavior, which breaks when creating multiple PeerConnections from the same PeerConnectionFactory.