### PR TITLE
Unsubscribe from Port events when doing ICE forking

### DIFF
--- a/p2p/base/fake_port_allocator.h
+++ b/p2p/base/fake_port_allocator.h
@@ -121,6 +121,7 @@ class FakePortAllocatorSession : public PortAllocatorSession {
                                       username(), password(), std::string(),
                                       false));
       RTC_DCHECK(port_);
+      // RingRTC change to support ICE forking
       port_->SignalDestroyed.connect(this, &FakePortAllocatorSession::OnPortDestroyed);
       AddPort(port_.get());
     }

--- a/p2p/base/fake_port_allocator.h
+++ b/p2p/base/fake_port_allocator.h
@@ -121,8 +121,7 @@ class FakePortAllocatorSession : public PortAllocatorSession {
                                       username(), password(), std::string(),
                                       false));
       RTC_DCHECK(port_);
-      port_->SubscribePortDestroyed(
-          [this](PortInterface* port) { OnPortDestroyed(port); });
+      port_->SignalDestroyed.connect(this, &FakePortAllocatorSession::OnPortDestroyed);
       AddPort(port_.get());
     }
     ++port_config_count_;

--- a/p2p/base/p2p_transport_channel.cc
+++ b/p2p/base/p2p_transport_channel.cc
@@ -250,7 +250,6 @@ P2PTransportChannel::P2PTransportChannel(
 
 P2PTransportChannel::~P2PTransportChannel() {
   TRACE_EVENT0("webrtc", "P2PTransportChannel::~P2PTransportChannel");
-  RTC_LOG(LS_ERROR) << "FLUFF P2PTransportChannel::~P2PTransportChannel this: " << this;
   RTC_DCHECK_RUN_ON(network_thread_);
   std::vector<Connection*> copy(connections().begin(), connections().end());
   for (Connection* con : copy) {
@@ -273,7 +272,7 @@ P2PTransportChannel::~P2PTransportChannel() {
     shared_gatherer_->port_allocator_session()
         ->SignalCandidatesAllocationDone.disconnect(this);
 
-    // With shared gatheres (ICE forking), the ports may stay alive
+    // With shared gatherers (ICE forking), the ports may stay alive
     // after the P2pTransportChannel, so we need to make sure we disconnect
     // from the signals that we listen to in OnPortReady.
     for (auto* port : ports_) {
@@ -1057,6 +1056,7 @@ void P2PTransportChannel::OnPortReady(PortAllocatorSession* session,
   }
 
   ports_.push_back(port);
+  // RingRTC change to support ICE forking
   port->SignalDestroyed.connect(this, &P2PTransportChannel::OnPortDestroyed);
   port->SignalSentPacket.connect(this, &P2PTransportChannel::OnSentPacket);
 
@@ -2276,11 +2276,7 @@ void P2PTransportChannel::OnConnectionDestroyed(Connection* connection) {
 // When a port is destroyed, remove it from our list of ports to use for
 // connection attempts.
 void P2PTransportChannel::OnPortDestroyed(PortInterface* port) {
-  RTC_LOG(LS_ERROR) << "FLUFF P2PTransportChannel::OnPortDestroyed this: " << this;
-  RTC_LOG(LS_ERROR) << "FLUFF P2PTransportChannel::OnPortDestroyed port: " << port;
   RTC_DCHECK_RUN_ON(network_thread_);
-  RTC_LOG(LS_ERROR) << "FLUFF P2PTransportChannel::OnPortDestroyed 2 this: " << this;
-  RTC_LOG(LS_ERROR) << "FLUFF P2PTransportChannel::OnPortDestroyed this.ports_.size(): " << this->ports_.size();
 
   ports_.erase(std::remove(ports_.begin(), ports_.end(), port), ports_.end());
   pruned_ports_.erase(

--- a/p2p/base/p2p_transport_channel.cc
+++ b/p2p/base/p2p_transport_channel.cc
@@ -1039,9 +1039,9 @@ void P2PTransportChannel::OnPortReady(PortAllocatorSession* session,
         this, &P2PTransportChannel::OnUnknownAddressFromOwnedSession);
   }
 
+  // %%%% unsubscribe
   ports_.push_back(port);
-  port->SubscribePortDestroyed(
-      [this](PortInterface* port) { OnPortDestroyed(port); });
+  port->SignalDestroyed.connect(this, &P2PTransportChannel::OnPortDestroyed);
   port->SignalSentPacket.connect(this, &P2PTransportChannel::OnSentPacket);
 
   // Attempt to create a connection from this new port to all of the remote

--- a/p2p/base/p2p_transport_channel.cc
+++ b/p2p/base/p2p_transport_channel.cc
@@ -272,6 +272,23 @@ P2PTransportChannel::~P2PTransportChannel() {
         ->SignalCandidatesRemoved.disconnect(this);
     shared_gatherer_->port_allocator_session()
         ->SignalCandidatesAllocationDone.disconnect(this);
+
+    // With shared gatheres (ICE forking), the ports may stay alive
+    // after the P2pTransportChannel, so we need to make sure we disconnect
+    // from the signals that we listen to in OnPortReady.
+    for (auto* port : ports_) {
+      port->SignalDestroyed.disconnect(this);
+      port->SignalSentPacket.disconnect(this);
+      port->SignalRoleConflict.disconnect(this);
+      port->SignalUnknownAddress.disconnect(this);
+    }
+    // And make sure you do it for pruned ports as well.
+    for (auto* port : pruned_ports_) {
+      port->SignalDestroyed.disconnect(this);
+      port->SignalSentPacket.disconnect(this);
+      port->SignalRoleConflict.disconnect(this);
+      port->SignalUnknownAddress.disconnect(this);
+    }
   }
 }
 
@@ -1039,7 +1056,6 @@ void P2PTransportChannel::OnPortReady(PortAllocatorSession* session,
         this, &P2PTransportChannel::OnUnknownAddressFromOwnedSession);
   }
 
-  // %%%% unsubscribe
   ports_.push_back(port);
   port->SignalDestroyed.connect(this, &P2PTransportChannel::OnPortDestroyed);
   port->SignalSentPacket.connect(this, &P2PTransportChannel::OnSentPacket);

--- a/p2p/base/p2p_transport_channel.cc
+++ b/p2p/base/p2p_transport_channel.cc
@@ -250,6 +250,7 @@ P2PTransportChannel::P2PTransportChannel(
 
 P2PTransportChannel::~P2PTransportChannel() {
   TRACE_EVENT0("webrtc", "P2PTransportChannel::~P2PTransportChannel");
+  RTC_LOG(LS_ERROR) << "FLUFF P2PTransportChannel::~P2PTransportChannel this: " << this;
   RTC_DCHECK_RUN_ON(network_thread_);
   std::vector<Connection*> copy(connections().begin(), connections().end());
   for (Connection* con : copy) {
@@ -2259,7 +2260,11 @@ void P2PTransportChannel::OnConnectionDestroyed(Connection* connection) {
 // When a port is destroyed, remove it from our list of ports to use for
 // connection attempts.
 void P2PTransportChannel::OnPortDestroyed(PortInterface* port) {
+  RTC_LOG(LS_ERROR) << "FLUFF P2PTransportChannel::OnPortDestroyed this: " << this;
+  RTC_LOG(LS_ERROR) << "FLUFF P2PTransportChannel::OnPortDestroyed port: " << port;
   RTC_DCHECK_RUN_ON(network_thread_);
+  RTC_LOG(LS_ERROR) << "FLUFF P2PTransportChannel::OnPortDestroyed 2 this: " << this;
+  RTC_LOG(LS_ERROR) << "FLUFF P2PTransportChannel::OnPortDestroyed this.ports_.size(): " << this->ports_.size();
 
   ports_.erase(std::remove(ports_.begin(), ports_.end(), port), ports_.end());
   pruned_ports_.erase(

--- a/p2p/base/port.cc
+++ b/p2p/base/port.cc
@@ -908,7 +908,7 @@ void Port::OnConnectionDestroyed(Connection* conn) {
 void Port::Destroy() {
   RTC_DCHECK(connections_.empty());
   RTC_LOG(LS_INFO) << ToString() << ": Port deleted";
-  RTC_LOG(LS_ERROR) << "FLUFF Port::Destory => SignalDestroyed this: " << this;
+  // RingRTC change to support ICE forking
   SignalDestroyed(this);
   delete this;
 }

--- a/p2p/base/port.cc
+++ b/p2p/base/port.cc
@@ -916,6 +916,7 @@ void Port::OnConnectionDestroyed(Connection* conn) {
 void Port::Destroy() {
   RTC_DCHECK(connections_.empty());
   RTC_LOG(LS_INFO) << ToString() << ": Port deleted";
+  RTC_LOG(LS_ERROR) << "FLUFF Port::Destory => SendPortDestroyed this: " << this;
   SendPortDestroyed(this);
   delete this;
 }

--- a/p2p/base/port.cc
+++ b/p2p/base/port.cc
@@ -844,14 +844,6 @@ void Port::OnMessage(rtc::Message* pmsg) {
   }
 }
 
-void Port::SubscribePortDestroyed(
-    std::function<void(PortInterface*)> callback) {
-  port_destroyed_callback_list_.AddReceiver(callback);
-}
-
-void Port::SendPortDestroyed(Port* port) {
-  port_destroyed_callback_list_.Send(port);
-}
 void Port::OnNetworkTypeChanged(const rtc::Network* network) {
   RTC_DCHECK(network == network_);
 
@@ -916,8 +908,8 @@ void Port::OnConnectionDestroyed(Connection* conn) {
 void Port::Destroy() {
   RTC_DCHECK(connections_.empty());
   RTC_LOG(LS_INFO) << ToString() << ": Port deleted";
-  RTC_LOG(LS_ERROR) << "FLUFF Port::Destory => SendPortDestroyed this: " << this;
-  SendPortDestroyed(this);
+  RTC_LOG(LS_ERROR) << "FLUFF Port::Destory => SignalDestroyed this: " << this;
+  SignalDestroyed(this);
   delete this;
 }
 

--- a/p2p/base/port.h
+++ b/p2p/base/port.h
@@ -277,9 +277,6 @@ class Port : public PortInterface,
   // connection.
   sigslot::signal1<Port*> SignalPortError;
 
-  void SubscribePortDestroyed(
-      std::function<void(PortInterface*)> callback) override;
-  void SendPortDestroyed(Port* port);
   // Returns a map containing all of the connections of this port, keyed by the
   // remote address.
   typedef std::map<rtc::SocketAddress, Connection*> AddressMap;

--- a/p2p/base/port_interface.h
+++ b/p2p/base/port_interface.h
@@ -115,6 +115,7 @@ class PortInterface {
   // Signaled when Port discovers ice role conflict with the peer.
   sigslot::signal1<PortInterface*> SignalRoleConflict;
 
+  // RingRTC change to support ICE forking
   sigslot::signal1<PortInterface*> SignalDestroyed;
 
   // Normally, packets arrive through a connection (or they result signaling of

--- a/p2p/base/port_interface.h
+++ b/p2p/base/port_interface.h
@@ -112,13 +112,10 @@ class PortInterface {
                                         int error_code,
                                         const std::string& reason) = 0;
 
-  // Signaled when this port decides to delete itself because it no longer has
-  // any usefulness.
-  virtual void SubscribePortDestroyed(
-      std::function<void(PortInterface*)> callback) = 0;
-
   // Signaled when Port discovers ice role conflict with the peer.
   sigslot::signal1<PortInterface*> SignalRoleConflict;
+
+  sigslot::signal1<PortInterface*> SignalDestroyed;
 
   // Normally, packets arrive through a connection (or they result signaling of
   // unknown address).  Calling this method turns off delivery of packets

--- a/p2p/base/port_unittest.cc
+++ b/p2p/base/port_unittest.cc
@@ -269,6 +269,7 @@ class TestChannel : public sigslot::has_slots<> {
   explicit TestChannel(std::unique_ptr<Port> p1) : port_(std::move(p1)) {
     port_->SignalPortComplete.connect(this, &TestChannel::OnPortComplete);
     port_->SignalUnknownAddress.connect(this, &TestChannel::OnUnknownAddress);
+    // RingRTC change to support ICE forking
     port_->SignalDestroyed.connect(this, &TestChannel::OnPortDestroyed);
   }
 
@@ -776,7 +777,8 @@ class PortTest : public ::testing::Test, public sigslot::has_slots<> {
   bool role_conflict() const { return role_conflict_; }
 
   void ConnectToSignalDestroyed(PortInterface* port) {
-    port->SignalDestroyed.connect(this, &TestChannel::OnPortDestroyed);
+    // RingRTC change to support ICE forking
+    port->SignalDestroyed.connect(this, &PortTest::OnDestroyed);
   }
 
   void OnDestroyed(PortInterface* port) { ++ports_destroyed_; }

--- a/p2p/base/port_unittest.cc
+++ b/p2p/base/port_unittest.cc
@@ -269,8 +269,7 @@ class TestChannel : public sigslot::has_slots<> {
   explicit TestChannel(std::unique_ptr<Port> p1) : port_(std::move(p1)) {
     port_->SignalPortComplete.connect(this, &TestChannel::OnPortComplete);
     port_->SignalUnknownAddress.connect(this, &TestChannel::OnUnknownAddress);
-    port_->SubscribePortDestroyed(
-        [this](PortInterface* port) { OnSrcPortDestroyed(port); });
+    port_->SignalDestroyed.connect(this, &TestChannel::OnPortDestroyed);
   }
 
   int complete_count() { return complete_count_; }
@@ -777,8 +776,7 @@ class PortTest : public ::testing::Test, public sigslot::has_slots<> {
   bool role_conflict() const { return role_conflict_; }
 
   void ConnectToSignalDestroyed(PortInterface* port) {
-    port->SubscribePortDestroyed(
-        [this](PortInterface* port) { OnDestroyed(port); });
+    port->SignalDestroyed.connect(this, &TestChannel::OnPortDestroyed);
   }
 
   void OnDestroyed(PortInterface* port) { ++ports_destroyed_; }

--- a/p2p/base/turn_port_unittest.cc
+++ b/p2p/base/turn_port_unittest.cc
@@ -354,6 +354,7 @@ class TurnPortTest : public ::testing::Test,
         this, &TurnPortTest::OnTurnRefreshResult);
     turn_port_->SignalTurnPortClosed.connect(this,
                                              &TurnPortTest::OnTurnPortClosed);
+    // RingRTC change to support ICE forking
     turn_port_->SignalDestroyed.connect(this, &TurnPortTest::OnTurnPortClosed);
   }
 

--- a/p2p/base/turn_port_unittest.cc
+++ b/p2p/base/turn_port_unittest.cc
@@ -354,8 +354,7 @@ class TurnPortTest : public ::testing::Test,
         this, &TurnPortTest::OnTurnRefreshResult);
     turn_port_->SignalTurnPortClosed.connect(this,
                                              &TurnPortTest::OnTurnPortClosed);
-    turn_port_->SubscribePortDestroyed(
-        [this](PortInterface* port) { OnTurnPortDestroyed(port); });
+    turn_port_->SignalDestroyed.connect(this, &TurnPortTest::OnTurnPortClosed);
   }
 
   void CreateUdpPort() { CreateUdpPort(kLocalAddr2); }

--- a/p2p/client/basic_port_allocator.cc
+++ b/p2p/client/basic_port_allocator.cc
@@ -969,7 +969,7 @@ void BasicPortAllocatorSession::AddAllocatedPort(Port* port,
       this, &BasicPortAllocatorSession::OnCandidateError);
   port->SignalPortComplete.connect(this,
                                    &BasicPortAllocatorSession::OnPortComplete);
-
+  // RingRTC change to support ICE forking
   port->SignalDestroyed.connect(this, &BasicPortAllocatorSession::OnPortDestroyed);
 
   port->SignalPortError.connect(this, &BasicPortAllocatorSession::OnPortError);
@@ -1503,7 +1503,7 @@ void AllocationSequence::CreateUDPPorts() {
     // UDPPort.
     if (IsFlagSet(PORTALLOCATOR_ENABLE_SHARED_SOCKET)) {
       udp_port_ = port.get();
-
+      // RingRTC change to support ICE forking
       port->SignalDestroyed.connect(this, &AllocationSequence::OnPortDestroyed);
 
       // If STUN is not disabled, setting stun server address to port.
@@ -1643,6 +1643,7 @@ void AllocationSequence::CreateTurnPort(const RelayServerConfig& config) {
       relay_ports_.push_back(port.get());
       // Listen to the port destroyed signal, to allow AllocationSequence to
       // remove the entry from it's map.
+      // RingRTC change to support ICE forking
       port->SignalDestroyed.connect(this, &AllocationSequence::OnPortDestroyed);
     } else {
       port = session_->allocator()->relay_port_factory()->Create(


### PR DESCRIPTION
This was causing a crash when switching networks after doing ICE forking.