### PR TITLE
Allow stereo output for multi-channel devices

### DIFF
--- a/modules/audio_device/mac/audio_mixer_manager_mac.cc
+++ b/modules/audio_device/mac/audio_mixer_manager_mac.cc
@@ -539,7 +539,8 @@ int32_t AudioMixerManagerMac::StereoPlayoutIsAvailable(bool& available) {
     return -1;
   }
 
-  available = (_noOutputChannels == 2);
+  // RingRTC change to allow output to stereo if more than 2 channels
+  available = (_noOutputChannels >= 2);
   return 0;
 }
 


### PR DESCRIPTION
Some audio interfaces support more than 2 channels and will normally support stereo playback over the first two.