### PR TITLE
Windows: Try to find multi-channel match and convert to stereo

### DIFF
--- a/modules/audio_device/win/core_audio_base_win.cc
+++ b/modules/audio_device/win/core_audio_base_win.cc
@@ -439,7 +439,7 @@ bool CoreAudioBase::Init() {
     if (!core_audio_utility::IsFormatSupported(
             audio_client.Get(), AUDCLNT_SHAREMODE_SHARED, &format_)) {
       // RingRTC change to try again to match a format for multi-channel.
-      if (params.channels() > 2) {
+      if (IsInput() && (params.channels() > 2)) {
         format->nChannels = params.channels();
         format->nBlockAlign = (format->wBitsPerSample / 8) * format->nChannels;
         format->nAvgBytesPerSec = format->nSamplesPerSec * format->nBlockAlign;

--- a/modules/audio_device/win/core_audio_base_win.cc
+++ b/modules/audio_device/win/core_audio_base_win.cc
@@ -438,7 +438,18 @@ bool CoreAudioBase::Init() {
   if (!sample_rate_) {
     if (!core_audio_utility::IsFormatSupported(
             audio_client.Get(), AUDCLNT_SHAREMODE_SHARED, &format_)) {
-      return false;
+      // RingRTC change to try again to match a format for multi-channel.
+      if (params.channels() > 2) {
+        format->nChannels = params.channels();
+        format->nBlockAlign = (format->wBitsPerSample / 8) * format->nChannels;
+        format->nAvgBytesPerSec = format->nSamplesPerSec * format->nBlockAlign;
+        if (!core_audio_utility::IsFormatSupported(
+            audio_client.Get(), AUDCLNT_SHAREMODE_SHARED, &format_)) {
+          return false;
+        }
+      } else {
+        return false;
+      }
     }
   }
 

--- a/modules/audio_device/win/core_audio_input_win.cc
+++ b/modules/audio_device/win/core_audio_input_win.cc
@@ -121,7 +121,10 @@ int CoreAudioInput::InitRecording() {
   WAVEFORMATEX* format = &format_.Format;
   RTC_DCHECK_EQ(format->wFormatTag, WAVE_FORMAT_EXTENSIBLE);
   audio_device_buffer_->SetRecordingSampleRate(format->nSamplesPerSec);
-  audio_device_buffer_->SetRecordingChannels(format->nChannels);
+
+  // RingRTC change to ensure that the audio_device_buffer is
+  // configured for a limit of either 1 or 2 channels.
+  audio_device_buffer_->SetRecordingChannels(std::min((UINT16)2, format->nChannels));
 
   // Create a modified audio buffer class which allows us to supply any number
   // of samples (and not only multiple of 10ms) to match the optimal buffer
@@ -355,11 +358,29 @@ bool CoreAudioInput::OnDataCallback(uint64_t device_frequency) {
                               format_.Format.nBlockAlign * num_frames_to_read);
       RTC_DLOG(LS_WARNING) << "Captured audio is replaced by silence";
     } else {
+      // RingRTC change to shift multiple channels to stereo channels.
+      UINT16 nChannels = format_.Format.nChannels;
+
+      if (nChannels > 2) {
+        int16_t* audio_data_src = (int16_t*)audio_data;
+        int16_t* audio_data_end = (int16_t*)audio_data + (num_frames_to_read * nChannels);
+        int16_t* audio_data_dst = (int16_t*)audio_data;
+
+        while (audio_data_src < audio_data_end) {
+          memmove(audio_data_dst, audio_data_src, 2 * sizeof(int16_t));
+          audio_data_src += nChannels;
+          audio_data_dst += 2;
+        }
+
+        // Reset nChannels to stereo now that the data is shifted.
+        nChannels = 2;
+      }
+
       // Copy recorded audio in `audio_data` to the WebRTC sink using the
       // FineAudioBuffer object.
       fine_audio_buffer_->DeliverRecordedData(
           rtc::MakeArrayView(reinterpret_cast<const int16_t*>(audio_data),
-                             format_.Format.nChannels * num_frames_to_read),
+                             nChannels * num_frames_to_read),
 
           latency_ms_);
     }

--- a/modules/audio_device/win/core_audio_input_win.cc
+++ b/modules/audio_device/win/core_audio_input_win.cc
@@ -365,8 +365,8 @@ bool CoreAudioInput::OnDataCallback(uint64_t device_frequency) {
         // Copy the first two channels of sample data from each frame and
         // shift to the beginning of the audio data buffer.
         int16_t* audio_data_ptr = (int16_t*)audio_data;
-        for (UINT32 i = 0; i < num_frames_to_read; ++i) {
-          memmove(&audio_data_ptr[i * 2], &audio_data_ptr[i * nChannels], 2 * sizeof(int16_t));
+        for (UINT32 i = 1; i < num_frames_to_read; ++i) {
+          memcpy(&audio_data_ptr[i * 2], &audio_data_ptr[i * nChannels], 2 * sizeof(int16_t));
         }
 
         // Reset nChannels to stereo now that the data is shifted.

--- a/modules/audio_device/win/core_audio_input_win.cc
+++ b/modules/audio_device/win/core_audio_input_win.cc
@@ -362,14 +362,11 @@ bool CoreAudioInput::OnDataCallback(uint64_t device_frequency) {
       UINT16 nChannels = format_.Format.nChannels;
 
       if (nChannels > 2) {
-        int16_t* audio_data_src = (int16_t*)audio_data;
-        int16_t* audio_data_end = (int16_t*)audio_data + (num_frames_to_read * nChannels);
-        int16_t* audio_data_dst = (int16_t*)audio_data;
-
-        while (audio_data_src < audio_data_end) {
-          memmove(audio_data_dst, audio_data_src, 2 * sizeof(int16_t));
-          audio_data_src += nChannels;
-          audio_data_dst += 2;
+        // Copy the first two channels of sample data from each frame and
+        // shift to the beginning of the audio data buffer.
+        int16_t* audio_data_ptr = (int16_t*)audio_data;
+        for (UINT32 i = 0; i < num_frames_to_read; ++i) {
+          memmove(&audio_data_ptr[i * 2], &audio_data_ptr[i * nChannels], 2 * sizeof(int16_t));
         }
 
         // Reset nChannels to stereo now that the data is shifted.


### PR DESCRIPTION
**Current Behavior**
The Windows ADM limits the acceptable input audio format to be mono (1-channel) or stereo (2-channel). Some "multi-channel mic array" drivers don't allow this format, resulting in a quiet initialization failure where input does not work (hence the remote user can't hear anything).

**Workaround**
If `IsFormatSupported` fails to find a match, try again allowing the channel count to exceed 2. Note that we still want the driver to provide 16-bit samples in PCM format, so the request may still fail. However, testing reveals that most drivers will do the conversion.

Then, when data is captured, shift the first 2 channels of all frames (assumed to be `Front_LEFT` and `FRONT_RIGHT`) to the beginning of the audio buffer before delivering it to the WebRTC sink.

The workaround changes only apply in multi-channel cases where `IsFormatSupported` fails to find a match for a stereo format. Some drivers actually support the conversion (_as they should!_) and that is preferred.