### PR TITLE
Convert common error and warning logs to info severity

### DIFF
--- a/audio/audio_send_stream.cc
+++ b/audio/audio_send_stream.cc
@@ -886,10 +886,10 @@ void AudioSendStream::RemoveBitrateObserver() {
 absl::optional<AudioSendStream::TargetAudioBitrateConstraints>
 AudioSendStream::GetMinMaxBitrateConstraints() const {
   if (config_.min_bitrate_bps < 0 || config_.max_bitrate_bps < 0) {
-    RTC_LOG(LS_WARNING) << "Config is invalid: min_bitrate_bps="
-                        << config_.min_bitrate_bps
-                        << "; max_bitrate_bps=" << config_.max_bitrate_bps
-                        << "; both expected greater or equal to 0";
+    RTC_LOG(LS_INFO) << "Config is invalid: min_bitrate_bps="
+                     << config_.min_bitrate_bps
+                     << "; max_bitrate_bps=" << config_.max_bitrate_bps
+                     << "; both expected greater or equal to 0";
     return absl::nullopt;
   }
   TargetAudioBitrateConstraints constraints{

--- a/call/rtp_video_sender.cc
+++ b/call/rtp_video_sender.cc
@@ -104,7 +104,7 @@ bool ShouldDisableRedAndUlpfec(bool flexfec_enabled,
   // Note that this is not the case with FlexFEC.
   if (nack_enabled && IsUlpfecEnabled() &&
       !PayloadTypeSupportsSkippingFecPackets(rtp_config.payload_name, trials)) {
-    RTC_LOG(LS_WARNING)
+    RTC_LOG(LS_INFO)
         << "Transmitting payload type without picture ID using "
            "NACK+ULPFEC is a waste of bandwidth since ULPFEC packets "
            "also have to be retransmitted. Disabling ULPFEC.";
@@ -113,7 +113,7 @@ bool ShouldDisableRedAndUlpfec(bool flexfec_enabled,
 
   // Verify payload types.
   if (IsUlpfecEnabled() ^ IsRedEnabled()) {
-    RTC_LOG(LS_WARNING)
+    RTC_LOG(LS_INFO)
         << "Only RED or only ULPFEC enabled, but not both. Disabling both.";
     should_disable_red_and_ulpfec = true;
   }

--- a/common_video/video_render_frames.cc
+++ b/common_video/video_render_frames.cc
@@ -55,7 +55,7 @@ int32_t VideoRenderFrames::AddFrame(VideoFrame&& new_frame) {
   // really slow system never renders any frames.
   if (!incoming_frames_.empty() &&
       new_frame.render_time_ms() + kOldRenderTimestampMS < time_now) {
-    RTC_LOG(LS_WARNING) << "Too old frame, timestamp=" << new_frame.timestamp();
+    RTC_LOG(LS_INFO) << "Too old frame, timestamp=" << new_frame.timestamp();
     ++frames_dropped_;
     return -1;
   }

--- a/common_video/video_render_frames.cc
+++ b/common_video/video_render_frames.cc
@@ -68,9 +68,9 @@ int32_t VideoRenderFrames::AddFrame(VideoFrame&& new_frame) {
   }
 
   if (new_frame.render_time_ms() < last_render_time_ms_) {
-    RTC_LOG(LS_WARNING) << "Frame scheduled out of order, render_time="
-                        << new_frame.render_time_ms()
-                        << ", latest=" << last_render_time_ms_;
+    RTC_LOG(LS_INFO) << "Frame scheduled out of order, render_time="
+                     << new_frame.render_time_ms()
+                     << ", latest=" << last_render_time_ms_;
     // For more details, see bug:
     // https://bugs.chromium.org/p/webrtc/issues/detail?id=7253
     ++frames_dropped_;

--- a/media/engine/adm_helpers.cc
+++ b/media/engine/adm_helpers.cc
@@ -59,7 +59,7 @@ void Init(AudioDeviceModule* adm) {
       RTC_LOG(LS_ERROR) << "Failed to query stereo playout.";
     }
     if (adm->SetStereoPlayout(available) != 0) {
-      RTC_LOG(LS_ERROR) << "Failed to set stereo playout mode.";
+      RTC_LOG(LS_INFO) << "Failed to set stereo playout mode.";
     }
   }
 
@@ -79,7 +79,7 @@ void Init(AudioDeviceModule* adm) {
       RTC_LOG(LS_ERROR) << "Failed to query stereo recording.";
     }
     if (adm->SetStereoRecording(available) != 0) {
-      RTC_LOG(LS_ERROR) << "Failed to set stereo recording mode.";
+      RTC_LOG(LS_INFO) << "Failed to set stereo recording mode.";
     }
   }
 }

--- a/media/engine/simulcast.cc
+++ b/media/engine/simulcast.cc
@@ -313,8 +313,8 @@ size_t LimitSimulcastLayerCount(int width,
                                    enable_lowres_bitrate_interpolation)
             .max_layers);
     if (layer_count > adaptive_layer_count) {
-      RTC_LOG(LS_WARNING) << "Reducing simulcast layer count from "
-                          << layer_count << " to " << adaptive_layer_count;
+      RTC_LOG(LS_INFO) << "Reducing simulcast layer count from "
+                       << layer_count << " to " << adaptive_layer_count;
       layer_count = adaptive_layer_count;
     }
   }

--- a/media/engine/webrtc_video_engine.cc
+++ b/media/engine/webrtc_video_engine.cc
@@ -3108,7 +3108,7 @@ void WebRtcVideoChannel::WebRtcVideoReceiveStream::OnFrame(
     estimated_remote_start_ntp_time_ms_ = frame.ntp_time_ms() - elapsed_time_ms;
 
   if (sink_ == NULL) {
-    RTC_LOG(LS_WARNING) << "VideoReceiveStream not connected to a VideoSink.";
+    RTC_LOG(LS_INFO) << "VideoReceiveStream not connected to a VideoSink.";
     return;
   }
 
@@ -3481,9 +3481,9 @@ void WebRtcVideoChannel::ClearRecordableEncodedFrameCallback(uint32_t ssrc) {
   if (stream) {
     stream->ClearRecordableEncodedFrameCallback();
   } else {
-    RTC_LOG(LS_ERROR) << "Absent receive stream; ignoring clearing encoded "
-                         "frame sink for ssrc "
-                      << ssrc;
+    RTC_LOG(LS_INFO) << "Absent receive stream; ignoring clearing encoded "
+                        "frame sink for ssrc "
+                     << ssrc;
   }
 }
 

--- a/media/engine/webrtc_voice_engine.cc
+++ b/media/engine/webrtc_voice_engine.cc
@@ -2077,7 +2077,7 @@ bool WebRtcVoiceMediaChannel::SetOutputVolume(uint32_t ssrc, double volume) {
                                         __func__, ssrc, volume);
   const auto it = recv_streams_.find(ssrc);
   if (it == recv_streams_.end()) {
-    RTC_LOG(LS_WARNING) << rtc::StringFormat(
+    RTC_LOG(LS_INFO) << rtc::StringFormat(
         "WRVMC::%s => (WARNING: no receive stream for SSRC %u)", __func__,
         ssrc);
     return false;

--- a/modules/audio_device/audio_device_generic.cc
+++ b/modules/audio_device/audio_device_generic.cc
@@ -15,7 +15,7 @@
 namespace webrtc {
 
 bool AudioDeviceGeneric::BuiltInAECIsAvailable() const {
-  RTC_LOG_F(LS_ERROR) << "Not supported on this platform";
+  RTC_LOG_F(LS_INFO) << "Not supported on this platform";
   return false;
 }
 
@@ -25,7 +25,7 @@ int32_t AudioDeviceGeneric::EnableBuiltInAEC(bool enable) {
 }
 
 bool AudioDeviceGeneric::BuiltInAGCIsAvailable() const {
-  RTC_LOG_F(LS_ERROR) << "Not supported on this platform";
+  RTC_LOG_F(LS_INFO) << "Not supported on this platform";
   return false;
 }
 
@@ -35,7 +35,7 @@ int32_t AudioDeviceGeneric::EnableBuiltInAGC(bool enable) {
 }
 
 bool AudioDeviceGeneric::BuiltInNSIsAvailable() const {
-  RTC_LOG_F(LS_ERROR) << "Not supported on this platform";
+  RTC_LOG_F(LS_INFO) << "Not supported on this platform";
   return false;
 }
 
@@ -45,7 +45,7 @@ int32_t AudioDeviceGeneric::EnableBuiltInNS(bool enable) {
 }
 
 int32_t AudioDeviceGeneric::GetPlayoutUnderrunCount() const {
-  RTC_LOG_F(LS_ERROR) << "Not supported on this platform";
+  RTC_LOG_F(LS_INFO) << "Not supported on this platform";
   return -1;
 }
 

--- a/modules/audio_device/win/audio_device_core_win.cc
+++ b/modules/audio_device/win/audio_device_core_win.cc
@@ -538,8 +538,8 @@ AudioDeviceWindowsCore::~AudioDeviceWindowsCore() {
           << "AudioDeviceWindowsCore::~AudioDeviceWindowsCore()"
              " failed to free the loaded Avrt DLL module correctly";
     } else {
-      RTC_LOG(LS_WARNING) << "AudioDeviceWindowsCore::~AudioDeviceWindowsCore()"
-                             " the Avrt DLL module is now unloaded";
+      RTC_LOG(LS_INFO) << "AudioDeviceWindowsCore::~AudioDeviceWindowsCore()"
+                          " the Avrt DLL module is now unloaded";
     }
   }
 }

--- a/modules/audio_device/win/core_audio_base_win.cc
+++ b/modules/audio_device/win/core_audio_base_win.cc
@@ -440,14 +440,17 @@ bool CoreAudioBase::Init() {
             audio_client.Get(), AUDCLNT_SHAREMODE_SHARED, &format_)) {
       // RingRTC change to try again to match a format for multi-channel.
       if (IsInput() && (params.channels() > 2)) {
+        RTC_LOG(LS_WARNING) << "Trying again to match for multi-channel";
         format->nChannels = params.channels();
         format->nBlockAlign = (format->wBitsPerSample / 8) * format->nChannels;
         format->nAvgBytesPerSec = format->nSamplesPerSec * format->nBlockAlign;
         if (!core_audio_utility::IsFormatSupported(
             audio_client.Get(), AUDCLNT_SHAREMODE_SHARED, &format_)) {
+          RTC_LOG(LS_ERROR) << "No multi-channel format matched";
           return false;
         }
       } else {
+        RTC_LOG(LS_ERROR) << "No format matched";
         return false;
       }
     }

--- a/modules/congestion_controller/goog_cc/goog_cc_network_control.cc
+++ b/modules/congestion_controller/goog_cc/goog_cc_network_control.cc
@@ -343,7 +343,7 @@ void GoogCcNetworkController::ClampConstraints() {
     min_data_rate_ = std::max(min_data_rate_, min_total_allocated_bitrate_);
   }
   if (max_data_rate_ < min_data_rate_) {
-    RTC_LOG(LS_WARNING) << "max bitrate smaller than min bitrate";
+    RTC_LOG(LS_INFO) << "max bitrate smaller than min bitrate";
     max_data_rate_ = min_data_rate_;
   }
   if (starting_rate_ && starting_rate_ < min_data_rate_) {

--- a/modules/congestion_controller/rtp/transport_feedback_adapter.cc
+++ b/modules/congestion_controller/rtp/transport_feedback_adapter.cc
@@ -261,9 +261,9 @@ TransportFeedbackAdapter::ProcessTransportFeedbackInner(
   }
 
   if (failed_lookups > 0) {
-    RTC_LOG(LS_WARNING) << "Failed to lookup send time for " << failed_lookups
-                        << " packet" << (failed_lookups > 1 ? "s" : "")
-                        << ". Send time history too small?";
+    RTC_LOG(LS_INFO) << "Failed to lookup send time for " << failed_lookups
+                     << " packet" << (failed_lookups > 1 ? "s" : "")
+                     << ". Send time history too small?";
   }
   if (ignored > 0) {
     RTC_LOG(LS_INFO) << "Ignoring " << ignored

--- a/modules/pacing/pacing_controller.cc
+++ b/modules/pacing/pacing_controller.cc
@@ -315,9 +315,9 @@ TimeDelta PacingController::UpdateTimeAndGetElapsed(Timestamp now) {
   TimeDelta elapsed_time = now - last_process_time_;
   last_process_time_ = now;
   if (elapsed_time > kMaxElapsedTime) {
-    RTC_LOG(LS_WARNING) << "Elapsed time (" << elapsed_time.ms()
-                        << " ms) longer than expected, limiting to "
-                        << kMaxElapsedTime.ms();
+    RTC_LOG(LS_INFO) << "Elapsed time (" << elapsed_time.ms()
+                     << " ms) longer than expected, limiting to "
+                     << kMaxElapsedTime.ms();
     elapsed_time = kMaxElapsedTime;
   }
   return elapsed_time;

--- a/modules/pacing/packet_router.cc
+++ b/modules/pacing/packet_router.cc
@@ -149,7 +149,7 @@ void PacketRouter::SendPacket(std::unique_ptr<RtpPacketToSend> packet,
   uint32_t ssrc = packet->Ssrc();
   auto kv = send_modules_map_.find(ssrc);
   if (kv == send_modules_map_.end()) {
-    RTC_LOG(LS_WARNING)
+    RTC_LOG(LS_INFO)
         << "Failed to send packet, matching RTP module not found "
            "or transport error. SSRC = "
         << packet->Ssrc() << ", sequence number " << packet->SequenceNumber();

--- a/modules/rtp_rtcp/source/rtcp_receiver.cc
+++ b/modules/rtp_rtcp/source/rtcp_receiver.cc
@@ -354,10 +354,10 @@ absl::optional<TimeDelta> RTCPReceiver::OnPeriodicRttUpdate(
     // Check for expired timers and if so, log and reset.
     auto now = clock_->CurrentTime();
     if (RtcpRrTimeoutLocked(now)) {
-      RTC_LOG_F(LS_WARNING) << "Timeout: No RTCP RR received.";
+      RTC_LOG_F(LS_INFO) << "Timeout: No RTCP RR received.";
     } else if (RtcpRrSequenceNumberTimeoutLocked(now)) {
-      RTC_LOG_F(LS_WARNING) << "Timeout: No increase in RTCP RR extended "
-                               "highest sequence number.";
+      RTC_LOG_F(LS_INFO) << "Timeout: No increase in RTCP RR extended "
+                            "highest sequence number.";
     }
   } else {
     // Report rtt from receiver.

--- a/modules/rtp_rtcp/source/rtp_sender.cc
+++ b/modules/rtp_rtcp/source/rtp_sender.cc
@@ -362,8 +362,8 @@ void RTPSender::OnReceivedNack(
     const int32_t bytes_sent = ReSendPacket(seq_no);
     if (bytes_sent < 0) {
       // Failed to send one Sequence number. Give up the rest in this nack.
-      RTC_LOG(LS_WARNING) << "Failed resending RTP packet " << seq_no
-                          << ", Discard rest of packets.";
+      RTC_LOG(LS_INFO) << "Failed resending RTP packet " << seq_no
+                       << ", Discard rest of packets.";
       break;
     }
   }

--- a/modules/video_coding/frame_buffer2.cc
+++ b/modules/video_coding/frame_buffer2.cc
@@ -444,9 +444,9 @@ int64_t FrameBuffer::InsertFrame(std::unique_ptr<EncodedFrame> frame) {
       ClearFramesAndHistory();
       last_continuous_frame_id = -1;
     } else {
-      RTC_LOG(LS_WARNING) << "Frame " << frame->Id() << " inserted after frame "
-                          << *last_decoded_frame
-                          << " was handed off for decoding, dropping frame.";
+      RTC_LOG(LS_INFO) << "Frame " << frame->Id() << " inserted after frame "
+                       << *last_decoded_frame
+                       << " was handed off for decoding, dropping frame.";
       return last_continuous_frame_id;
     }
   }
@@ -580,7 +580,7 @@ bool FrameBuffer::UpdateFrameInfoWithIncomingFrame(const EncodedFrame& frame,
       if (!decoded_frames_history_.WasDecoded(frame.references[i])) {
         int64_t now_ms = clock_->TimeInMilliseconds();
         if (last_log_non_decoded_ms_ + kLogNonDecodedIntervalMs < now_ms) {
-          RTC_LOG(LS_WARNING)
+          RTC_LOG(LS_INFO)
               << "Frame " << frame.Id()
               << " depends on a non-decoded frame more previous than the last "
                  "decoded frame, dropping frame.";

--- a/modules/video_coding/nack_requester.cc
+++ b/modules/video_coding/nack_requester.cc
@@ -354,8 +354,8 @@ std::vector<uint16_t> NackRequester::GetNackBatch(NackFilterOptions options) {
       ++it->second.retries;
       it->second.sent_at_time = now.ms();
       if (it->second.retries >= kMaxNackRetries) {
-        RTC_LOG(LS_WARNING) << "Sequence number " << it->second.seq_num
-                            << " removed from NACK list due to max retries.";
+        RTC_LOG(LS_INFO) << "Sequence number " << it->second.seq_num
+                         << " removed from NACK list due to max retries.";
         it = nack_list_.erase(it);
       } else {
         ++it;

--- a/modules/video_coding/rtp_vp8_ref_finder.cc
+++ b/modules/video_coding/rtp_vp8_ref_finder.cc
@@ -162,11 +162,11 @@ RtpVp8RefFinder::FrameDecision RtpVp8RefFinder::ManageFrameInternal(
 
     if (!(AheadOf<uint16_t, kFrameIdLength>(frame->Id(),
                                             layer_info_it->second[layer]))) {
-      RTC_LOG(LS_WARNING) << "Frame with picture id " << frame->Id()
-                          << " and packet range [" << frame->first_seq_num()
-                          << ", " << frame->last_seq_num()
-                          << "] already received, "
-                             " dropping frame.";
+      RTC_LOG(LS_INFO) << "Frame with picture id " << frame->Id()
+                       << " and packet range [" << frame->first_seq_num()
+                       << ", " << frame->last_seq_num()
+                       << "] already received, "
+                          " dropping frame.";
       return kDrop;
     }
 

--- a/p2p/base/basic_packet_socket_factory.cc
+++ b/p2p/base/basic_packet_socket_factory.cc
@@ -179,7 +179,7 @@ AsyncPacketSocket* BasicPacketSocketFactory::CreateClientTcpSocket(
   }
 
   if (socket->Connect(remote_address) < 0) {
-    RTC_LOG(LS_ERROR) << "TCP connect failed with error " << socket->GetError();
+    RTC_LOG(LS_INFO) << "TCP connect failed with error " << socket->GetError();
     delete socket;
     return NULL;
   }

--- a/p2p/base/connection.cc
+++ b/p2p/base/connection.cc
@@ -442,10 +442,10 @@ void Connection::OnSendStunPacket(const void* data,
   auto err =
       port_->SendTo(data, size, remote_candidate_.address(), options, false);
   if (err < 0) {
-    RTC_LOG(LS_WARNING) << ToString()
-                        << ": Failed to send STUN ping "
-                           " err="
-                        << err << " id=" << rtc::hex_encode(req->id());
+    RTC_LOG(LS_INFO) << ToString()
+                     << ": Failed to send STUN ping "
+                        " err="
+                     << err << " id=" << rtc::hex_encode(req->id());
   }
 }
 
@@ -712,10 +712,10 @@ void Connection::SendResponseMessage(const StunMessage& response) {
       rtc::PacketType::kIceConnectivityCheckResponse;
   auto err = port_->SendTo(buf.Data(), buf.Length(), addr, options, false);
   if (err < 0) {
-    RTC_LOG(LS_ERROR) << ToString() << ": Failed to send "
-                      << StunMethodToString(response.type())
-                      << ", to=" << addr.ToSensitiveString() << ", err=" << err
-                      << ", id=" << rtc::hex_encode(response.transaction_id());
+    RTC_LOG(LS_INFO) << ToString() << ": Failed to send "
+                     << StunMethodToString(response.type())
+                     << ", to=" << addr.ToSensitiveString() << ", err=" << err
+                     << ", id=" << rtc::hex_encode(response.transaction_id());
   } else {
     // Log at LS_INFO if we send a stun ping response on an unwritable
     // connection.
@@ -1253,7 +1253,7 @@ void Connection::MaybeUpdateLocalCandidate(ConnectionRequest* request,
   const StunAddressAttribute* addr =
       response->GetAddress(STUN_ATTR_XOR_MAPPED_ADDRESS);
   if (!addr) {
-    RTC_LOG(LS_WARNING)
+    RTC_LOG(LS_INFO)
         << "Connection::OnConnectionRequestResponse - "
            "No MAPPED-ADDRESS or XOR-MAPPED-ADDRESS found in the "
            "stun response message";

--- a/p2p/base/p2p_transport_channel.cc
+++ b/p2p/base/p2p_transport_channel.cc
@@ -1186,7 +1186,7 @@ void P2PTransportChannel::OnUnknownAddress(PortInterface* port,
     // If we don't know that the remote ufrag and the session is shared between
     // different transports, then don't create a peer reflexive candidate.
     // Otherwise, each transport would end up with one.
-    RTC_LOG(LS_WARNING)
+    RTC_LOG(LS_INFO)
         << "Ignoring peer-refexive ICE candidate because the ufrag is unknown.";
     return;
   }
@@ -1397,7 +1397,7 @@ void P2PTransportChannel::AddRemoteCandidate(const Candidate& candidate) {
     } else {
       // The candidate belongs to the next generation. Its pwd will be set
       // when the new remote ICE credentials arrive.
-      RTC_LOG(LS_WARNING)
+      RTC_LOG(LS_INFO)
           << "A remote candidate arrives with an unknown ufrag: "
           << candidate.username();
     }

--- a/p2p/base/port.cc
+++ b/p2p/base/port.cc
@@ -368,9 +368,9 @@ void Port::OnReadPacket(const char* data,
   std::unique_ptr<IceMessage> msg;
   std::string remote_username;
   if (!GetStunMessage(data, size, addr, &msg, &remote_username)) {
-    RTC_LOG(LS_ERROR) << ToString()
-                      << ": Received non-STUN packet from unknown address: "
-                      << addr.ToSensitiveString();
+    RTC_LOG(LS_INFO) << ToString()
+                     << ": Received non-STUN packet from unknown address: "
+                     << addr.ToSensitiveString();
   } else if (!msg) {
     // STUN message handled already
   } else if (msg->type() == STUN_BINDING_REQUEST) {

--- a/p2p/base/stun_port.cc
+++ b/p2p/base/stun_port.cc
@@ -93,9 +93,9 @@ class StunBindingRequest : public StunRequest {
     }
   }
   void OnTimeout() override {
-    RTC_LOG(LS_ERROR) << "Binding request timed out from "
-                      << port_->GetLocalAddress().ToSensitiveString() << " ("
-                      << port_->Network()->name() << ")";
+    RTC_LOG(LS_INFO) << "Binding request timed out from "
+                     << port_->GetLocalAddress().ToSensitiveString() << " ("
+                     << port_->Network()->name() << ")";
     port_->OnStunBindingOrResolveRequestFailed(
         server_addr_, SERVER_NOT_REACHABLE_ERROR,
         "STUN allocate request timed out.");
@@ -307,10 +307,10 @@ int UDPPort::SendTo(const void* data,
     // TODO(webrtc:9622): Use general rate limiting mechanism once it exists.
     if (send_error_count_ < kSendErrorLogLimit) {
       ++send_error_count_;
-      RTC_LOG(LS_ERROR) << ToString() << ": UDP send of " << size
-                        << " bytes to host " << addr.ToSensitiveString() << " ("
-                        << addr.ToResolvedSensitiveString()
-                        << ") failed with error " << error_;
+      RTC_LOG(LS_INFO) << ToString() << ": UDP send of " << size
+                       << " bytes to host " << addr.ToSensitiveString() << " ("
+                       << addr.ToResolvedSensitiveString()
+                       << ") failed with error " << error_;
     }
   } else {
     send_error_count_ = 0;
@@ -453,9 +453,9 @@ void UDPPort::OnResolveResult(const rtc::SocketAddress& input, int error) {
   rtc::SocketAddress resolved;
   if (error != 0 || !resolver_->GetResolvedAddress(
                         input, Network()->GetBestIP().family(), &resolved)) {
-    RTC_LOG(LS_WARNING) << ToString()
-                        << ": StunPort: stun host lookup received error "
-                        << error;
+    RTC_LOG(LS_INFO) << ToString()
+                     << ": StunPort: stun host lookup received error "
+                     << error;
     OnStunBindingOrResolveRequestFailed(input, SERVER_NOT_REACHABLE_ERROR,
                                         "STUN host lookup received error.");
     return;
@@ -599,7 +599,7 @@ void UDPPort::OnSendPacket(const void* data, size_t size, StunRequest* req) {
   options.info_signaled_after_sent.packet_type = rtc::PacketType::kStunMessage;
   CopyPortInformationToPacketInfo(&options.info_signaled_after_sent);
   if (socket_->SendTo(data, size, sreq->server_addr(), options) < 0) {
-    RTC_LOG_ERR_EX(LERROR, socket_->GetError())
+    RTC_LOG_ERR_EX(LS_INFO, socket_->GetError())
         << "UDP send of " << size << " bytes to host "
         << sreq->server_addr().ToSensitiveString() << " ("
         << sreq->server_addr().ToResolvedSensitiveString()

--- a/p2p/base/turn_port.cc
+++ b/p2p/base/turn_port.cc
@@ -376,7 +376,7 @@ void TurnPort::PrepareAddress() {
                      << ProtoToString(server_address_.proto) << " @ "
                      << server_address_.address.ToSensitiveString();
     if (!CreateTurnClientSocket()) {
-      RTC_LOG(LS_ERROR) << "Failed to create TURN client socket";
+      RTC_LOG(LS_INFO) << "Failed to create TURN client socket";
       OnAllocateError(SERVER_NOT_REACHABLE_ERROR,
                       "Failed to create TURN client socket.");
       return;
@@ -478,13 +478,13 @@ void TurnPort::OnSocketConnect(rtc::AsyncPacketSocket* socket) {
                         return socket_address.ipaddr() == addr;
                       })) {
     if (socket->GetLocalAddress().IsLoopbackIP()) {
-      RTC_LOG(LS_WARNING) << "Socket is bound to the address:"
-                          << socket_address.ipaddr().ToSensitiveString()
-                          << ", rather than an address associated with network:"
-                          << Network()->ToString()
-                          << ". Still allowing it since it's localhost.";
+      RTC_LOG(LS_INFO) << "Socket is bound to the address:"
+                       << socket_address.ipaddr().ToSensitiveString()
+                       << ", rather than an address associated with network:"
+                       << Network()->ToString()
+                       << ". Still allowing it since it's localhost.";
     } else if (IPIsAny(Network()->GetBestIP())) {
-      RTC_LOG(LS_WARNING)
+      RTC_LOG(LS_INFO)
           << "Socket is bound to the address:"
           << socket_address.ipaddr().ToSensitiveString()
           << ", rather than an address associated with network:"
@@ -492,10 +492,10 @@ void TurnPort::OnSocketConnect(rtc::AsyncPacketSocket* socket) {
           << ". Still allowing it since it's the 'any' address"
              ", possibly caused by multiple_routes being disabled.";
     } else {
-      RTC_LOG(LS_WARNING) << "Socket is bound to the address:"
-                          << socket_address.ipaddr().ToSensitiveString()
-                          << ", rather than an address associated with network:"
-                          << Network()->ToString() << ". Discarding TURN port.";
+      RTC_LOG(LS_INFO) << "Socket is bound to the address:"
+                       << socket_address.ipaddr().ToSensitiveString()
+                       << ", rather than an address associated with network:"
+                       << Network()->ToString() << ". Discarding TURN port.";
       OnAllocateError(
           STUN_ERROR_GLOBAL_FAILURE,
           "Address not associated with the desired network interface.");
@@ -823,8 +823,8 @@ void TurnPort::OnResolveResult(rtc::AsyncResolverInterface* resolver) {
   if (resolver_->GetError() != 0 ||
       !resolver_->GetResolvedAddress(Network()->GetBestIP().family(),
                                      &resolved_address)) {
-    RTC_LOG(LS_WARNING) << ToString() << ": TURN host lookup received error "
-                        << resolver_->GetError();
+    RTC_LOG(LS_INFO) << ToString() << ": TURN host lookup received error "
+                     << resolver_->GetError();
     error_ = resolver_->GetError();
     OnAllocateError(SERVER_NOT_REACHABLE_ERROR,
                     "TURN host lookup received error.");
@@ -845,8 +845,8 @@ void TurnPort::OnSendStunPacket(const void* data,
   options.info_signaled_after_sent.packet_type = rtc::PacketType::kTurnMessage;
   CopyPortInformationToPacketInfo(&options.info_signaled_after_sent);
   if (Send(data, size, options) < 0) {
-    RTC_LOG(LS_ERROR) << ToString() << ": Failed to send TURN message, error: "
-                      << socket_->GetError();
+    RTC_LOG(LS_INFO) << ToString() << ": Failed to send TURN message, error: "
+                     << socket_->GetError();
   }
 }
 
@@ -1462,8 +1462,8 @@ void TurnAllocateRequest::OnErrorResponse(StunMessage* response) {
 }
 
 void TurnAllocateRequest::OnTimeout() {
-  RTC_LOG(LS_WARNING) << port_->ToString() << ": TURN allocate request "
-                      << rtc::hex_encode(id()) << " timeout";
+  RTC_LOG(LS_INFO) << port_->ToString() << ": TURN allocate request "
+                   << rtc::hex_encode(id()) << " timeout";
   port_->OnAllocateRequestTimeout();
 }
 

--- a/p2p/base/turn_port.cc
+++ b/p2p/base/turn_port.cc
@@ -515,9 +515,9 @@ void TurnPort::OnSocketConnect(rtc::AsyncPacketSocket* socket) {
 }
 
 void TurnPort::OnSocketClose(rtc::AsyncPacketSocket* socket, int error) {
-  RTC_LOG(LS_WARNING) << ToString()
-                      << ": Connection with server failed with error: "
-                      << error;
+  RTC_LOG(LS_INFO) << ToString()
+                   << ": Connection with server failed with error: "
+                   << error;
   RTC_DCHECK(socket == socket_);
   Close();
 }

--- a/p2p/client/basic_port_allocator.cc
+++ b/p2p/client/basic_port_allocator.cc
@@ -995,7 +995,7 @@ void BasicPortAllocatorSession::OnCandidateReady(Port* port,
   // Discarding any candidate signal if port allocation status is
   // already done with gathering.
   if (!data->inprogress()) {
-    RTC_LOG(LS_WARNING)
+    RTC_LOG(LS_INFO)
         << "Discarding candidate because port is already done gathering.";
     return;
   }

--- a/pc/rtp_sender.cc
+++ b/pc/rtp_sender.cc
@@ -600,7 +600,7 @@ void VideoRtpSender::AttachTrack() {
 }
 
 rtc::scoped_refptr<DtmfSenderInterface> VideoRtpSender::GetDtmfSender() const {
-  RTC_LOG(LS_ERROR) << "Tried to get DTMF sender from video sender.";
+  RTC_LOG(LS_INFO) << "Tried to get DTMF sender from video sender.";
   return nullptr;
 }
 

--- a/pc/rtp_transport.cc
+++ b/pc/rtp_transport.cc
@@ -148,7 +148,7 @@ bool RtpTransport::SendPacket(bool rtcp,
                                   options, flags);
   if (ret != static_cast<int>(packet->size())) {
     if (transport->GetError() == ENOTCONN) {
-      RTC_LOG(LS_WARNING) << "Got ENOTCONN from transport.";
+      RTC_LOG(LS_INFO) << "Got ENOTCONN from transport.";
       SetReadyToSend(rtcp, false);
     }
     return false;
@@ -192,8 +192,8 @@ void RtpTransport::DemuxPacket(rtc::CopyOnWriteBuffer packet,
   }
 
   if (!rtp_demuxer_.OnRtpPacket(parsed_packet)) {
-    RTC_LOG(LS_WARNING) << "Failed to demux RTP packet: "
-                        << RtpDemuxer::DescribePacket(parsed_packet);
+    RTC_LOG(LS_INFO) << "Failed to demux RTP packet: "
+                     << RtpDemuxer::DescribePacket(parsed_packet);
   }
 }
 
@@ -264,7 +264,7 @@ void RtpTransport::OnReadPacket(rtc::PacketTransportInternal* transport,
   // RingRTC change to avoid processing RTP packets too soon
   if (!incoming_rtp_enabled_) {
     if (packet_type == cricket::RtpPacketType::kRtcp) {
-      RTC_LOG(LS_WARNING) << "Dropping RTCP packet because incoming RTP is disabled; len: " << len;
+      RTC_LOG(LS_INFO) << "Dropping RTCP packet because incoming RTP is disabled; len: " << len;
       return;
     } else {
       RTC_LOG(LS_INFO) << "Dropping RTP packet because incoming RTP is disabled; len: " << len;

--- a/pc/used_ids.h
+++ b/pc/used_ids.h
@@ -52,8 +52,8 @@ class UsedIds {
 
     if (IsIdUsed(original_id)) {
       new_id = FindUnusedId();
-      RTC_LOG(LS_WARNING) << "Duplicate id found. Reassigning from "
-                          << original_id << " to " << new_id;
+      RTC_LOG(LS_INFO) << "Duplicate id found. Reassigning from "
+                       << original_id << " to " << new_id;
       idstruct->id = new_id;
     }
     SetIdUsed(new_id);

--- a/rtc_base/physical_socket_server.cc
+++ b/rtc_base/physical_socket_server.cc
@@ -595,7 +595,7 @@ int PhysicalSocket::TranslateOption(Option opt, int* slevel, int* sopt) {
       }
       break;
 #else
-      RTC_LOG(LS_WARNING) << "Socket::OPT_DSCP not supported.";
+      RTC_LOG(LS_INFO) << "Socket::OPT_DSCP not supported.";
       return -1;
 #endif
     case OPT_RTP_SENDTIME_EXTN_ID:
@@ -1654,7 +1654,7 @@ bool PhysicalSocketServer::Wait(int cmsWait, bool process_io) {
               }
               if ((wsaEvents.lNetworkEvents & FD_CONNECT) &&
                   wsaEvents.iErrorCode[FD_CONNECT_BIT] != 0) {
-                RTC_LOG(WARNING)
+                RTC_LOG(LS_INFO)
                     << "PhysicalSocketServer got FD_CONNECT_BIT error "
                     << wsaEvents.iErrorCode[FD_CONNECT_BIT];
               }

--- a/sdk/objc/components/capturer/RTCCameraVideoCapturer.m
+++ b/sdk/objc/components/capturer/RTCCameraVideoCapturer.m
@@ -344,7 +344,7 @@ const int64_t kNanosecondsPerSecond = 1000000000;
 
 - (void)handleCaptureSessionRuntimeError:(NSNotification *)notification {
   NSError *error = [notification.userInfo objectForKey:AVCaptureSessionErrorKey];
-  RTCLogError(@"Capture session runtime error: %@", error);
+  RTCLogInfo(@"Capture session runtime error: %@", error);
 
   [RTC_OBJC_TYPE(RTCDispatcher) dispatchAsyncOnType:RTCDispatcherTypeCaptureSession
                                               block:^{
@@ -380,11 +380,11 @@ const int64_t kNanosecondsPerSecond = 1000000000;
       dispatchAsyncOnType:RTCDispatcherTypeCaptureSession
                     block:^{
                       if (!self.hasRetriedOnFatalError) {
-                        RTCLogWarning(@"Attempting to recover from fatal capture error.");
+                        RTCLogInfo(@"Attempting to recover from fatal capture error.");
                         [self handleNonFatalError];
                         self.hasRetriedOnFatalError = YES;
                       } else {
-                        RTCLogError(@"Previous fatal error recovery failed.");
+                        RTCLogInfo(@"Previous fatal error recovery failed.");
                       }
                     }];
 }

--- a/sdk/objc/components/capturer/RTCCameraVideoCapturer.m
+++ b/sdk/objc/components/capturer/RTCCameraVideoCapturer.m
@@ -309,7 +309,7 @@ const int64_t kNanosecondsPerSecond = 1000000000;
   // DroppedFrameReason unavailable on macOS.
   CFStringRef droppedReason = nil;
 #endif
-  RTCLogError(@"Dropped sample buffer. Reason: %@", (__bridge NSString *)droppedReason);
+  RTCLogInfo(@"Dropped sample buffer. Reason: %@", (__bridge NSString *)droppedReason);
 }
 
 #pragma mark - AVCaptureSession notifications

--- a/sdk/objc/native/src/audio/audio_device_ios.mm
+++ b/sdk/objc/native/src/audio/audio_device_ios.mm
@@ -452,9 +452,9 @@ OSStatus AudioDeviceIOS::OnGetPlayoutData(AudioUnitRenderActionFlags* flags,
     const int64_t delta_time = now_time - last_playout_time_;
     const int glitch_threshold = 1.6 * playout_parameters_.GetBufferSizeInMilliseconds();
     if (delta_time > glitch_threshold) {
-      RTCLogWarning(@"Possible playout audio glitch detected.\n"
-                     "  Time since last OnGetPlayoutData was %lld ms.\n",
-                    delta_time);
+      RTCLogInfo(@"Possible playout audio glitch detected.\n"
+                  "  Time since last OnGetPlayoutData was %lld ms.\n",
+                  delta_time);
       // Exclude extreme delta values since they do most likely not correspond
       // to a real glitch. Instead, the most probable cause is that a headset
       // has been plugged in or out. There are more direct ways to detect

--- a/sdk/objc/native/src/audio/audio_device_ios.mm
+++ b/sdk/objc/native/src/audio/audio_device_ios.mm
@@ -881,7 +881,7 @@ void AudioDeviceIOS::UnconfigureAudioSession() {
   RTC_DCHECK_RUN_ON(&thread_checker_);
   RTCLog(@"Unconfiguring audio session.");
   if (!has_configured_session_) {
-    RTCLogWarning(@"Audio session already unconfigured.");
+    RTCLogInfo(@"Audio session already unconfigured.");
     return;
   }
   RTC_OBJC_TYPE(RTCAudioSession)* session = [RTC_OBJC_TYPE(RTCAudioSession) sharedInstance];
@@ -1041,7 +1041,7 @@ int32_t AudioDeviceIOS::SpeakerMute(bool& enabled) const {
 }
 
 int32_t AudioDeviceIOS::SetPlayoutDevice(uint16_t index) {
-  RTC_LOG_F(LS_WARNING) << "Not implemented";
+  RTC_LOG_F(LS_INFO) << "Not implemented";
   return 0;
 }
 
@@ -1094,7 +1094,7 @@ int32_t AudioDeviceIOS::StereoPlayoutIsAvailable(bool& available) {
 }
 
 int32_t AudioDeviceIOS::SetStereoPlayout(bool enable) {
-  RTC_LOG_F(LS_WARNING) << "Not implemented";
+  RTC_LOG_F(LS_INFO) << "Not implemented";
   return -1;
 }
 
@@ -1143,7 +1143,7 @@ int32_t AudioDeviceIOS::RecordingDeviceName(uint16_t index,
 }
 
 int32_t AudioDeviceIOS::SetRecordingDevice(uint16_t index) {
-  RTC_LOG_F(LS_WARNING) << "Not implemented";
+  RTC_LOG_F(LS_INFO) << "Not implemented";
   return 0;
 }
 

--- a/sdk/objc/native/src/audio/audio_device_module_ios.mm
+++ b/sdk/objc/native/src/audio/audio_device_module_ios.mm
@@ -329,7 +329,7 @@ AudioDeviceModuleIOS::AudioDeviceModuleIOS(bool bypass_voice_processing)
       return -1;
     }
     if (audio_device_->SetStereoPlayout(enable)) {
-      RTC_LOG(WARNING) << "stereo playout is not supported";
+      RTC_LOG(INFO) << "stereo playout is not supported";
       return -1;
     }
     int8_t nChannels(1);

--- a/sdk/objc/native/src/audio/voice_processing_audio_unit.mm
+++ b/sdk/objc/native/src/audio/voice_processing_audio_unit.mm
@@ -280,8 +280,8 @@ bool VoiceProcessingAudioUnit::Initialize(Float64 sample_rate) {
   UInt32 agc_is_enabled = 0;
   result = GetAGCState(vpio_unit_, &agc_is_enabled);
   if (result != noErr) {
-    RTCLogError(@"Failed to get AGC state (1st attempt). "
-                 "Error=%ld.",
+    RTCLogInfo(@"Failed to get AGC state (1st attempt). "
+                "Error=%ld.",
                 (long)result);
     // Example of error code: kAudioUnitErr_NoConnection (-10876).
     // All error codes related to audio units are negative and are therefore

--- a/video/buffered_frame_decryptor.cc
+++ b/video/buffered_frame_decryptor.cc
@@ -40,7 +40,7 @@ void BufferedFrameDecryptor::ManageEncryptedFrame(
   switch (DecryptFrame(encrypted_frame.get())) {
     case FrameDecision::kStash:
       if (stashed_frames_.size() >= kMaxStashedFrames) {
-        RTC_LOG(LS_WARNING) << "Encrypted frame stash full poping oldest item.";
+        RTC_LOG(LS_INFO) << "Encrypted frame stash full poping oldest item.";
         stashed_frames_.pop_front();
       }
       stashed_frames_.push_back(std::move(encrypted_frame));

--- a/video/video_receive_stream2.cc
+++ b/video/video_receive_stream2.cc
@@ -918,8 +918,8 @@ void VideoReceiveStream2::HandleFrameBufferTimeout(int64_t now_ms,
   if (stream_is_active && !IsReceivingKeyFrame(now_ms) &&
       (!config_.crypto_options.sframe.require_frame_encryption ||
        rtp_video_stream_receiver_.IsDecryptable())) {
-    RTC_LOG(LS_WARNING) << "No decodable frame in " << wait_ms
-                        << " ms, requesting keyframe.";
+    RTC_LOG(LS_INFO) << "No decodable frame in " << wait_ms
+                     << " ms, requesting keyframe.";
     RequestKeyFrame(now_ms);
   }
 }


### PR DESCRIPTION
Currently, Signal clients don't show WebRTC logs because even in normal conditions, there is a lot of noise. For example, many stun/turn requests can fail with errors, but it does not have a direct negative effect on a media session.

By moving these common error and warning logs to the `info` severity level, we can log actual errors and warnings. 