### PR TITLE
Tell the AudioSendStream the correct frame length when configuring opus.

### DIFF
--- a/audio/audio_send_stream.cc
+++ b/audio/audio_send_stream.cc
@@ -945,6 +945,7 @@ void AudioSendStream::ConfigureEncoder(const webrtc::AudioEncoder::Config& confi
   // it doesn't actually change.
   config_.min_bitrate_bps = config.min_bitrate_bps;
   config_.max_bitrate_bps = config.max_bitrate_bps;
+  frame_length_range_ = {{TimeDelta::Millis(config.packet_size_ms), TimeDelta::Millis(config.packet_size_ms)}};
   channel_send_->CallEncoder([&](AudioEncoder* encoder) {
     if (!encoder->Configure(config)) {
       RTC_LOG(LS_INFO) << "Failed to configure audio send stream";


### PR DESCRIPTION
When the audio bitrate adaption experiment is enabled, the frame length was wrong and the wrong bitrates were being used.  This fixes that.  It doesn't matter if we disable the experiment, which we plan to do, but we should fix this just in case it affects other things or if we ever re-enable the experiment.