### PR TITLE
Windows: Support multi-channel output

### DIFF
--- a/modules/audio_device/win/core_audio_base_win.cc
+++ b/modules/audio_device/win/core_audio_base_win.cc
@@ -388,15 +388,27 @@ bool CoreAudioBase::Init() {
     }
   }
 
+  // RingRTC change to get the mix_format keep it in scope for multi-channel.
+  WAVEFORMATPCMEX mix_format;
+  HRESULT res = core_audio_utility::GetSharedModeMixFormat(
+      audio_client.Get(), &mix_format);
+  if (FAILED(res)) {
+    return false;
+  }
+
+  RTC_LOG(LS_WARNING) << (IsInput() ? "input " : "output ")
+                      << "mix_format: "
+                      << core_audio_utility::WaveFormatToString(&mix_format);
+
   // Retrieve preferred audio input or output parameters for the given client
   // and the specified client properties. Override the preferred rate if sample
   // rate has been defined by the user. Rate conversion will be performed by
   // the audio engine to match the client if needed.
   AudioParameters params;
-  HRESULT res = sample_rate_ ? core_audio_utility::GetPreferredAudioParameters(
-                                   audio_client.Get(), &params, *sample_rate_)
-                             : core_audio_utility::GetPreferredAudioParameters(
-                                   audio_client.Get(), &params);
+  res = sample_rate_ ? core_audio_utility::GetPreferredAudioParameters(
+                           audio_client.Get(), &params, &mix_format, *sample_rate_)
+                     : core_audio_utility::GetPreferredAudioParameters(
+                           audio_client.Get(), &params, &mix_format);
   if (FAILED(res)) {
     return false;
   }
@@ -414,9 +426,7 @@ bool CoreAudioBase::Init() {
     // TODO(henrika): ensure that this approach works on different multi-channel
     // devices. Verified on:
     // - Corsair VOID PRO Surround USB Adapter (supports 7.1)
-    RTC_LOG(LS_WARNING)
-        << "Using channel upmixing in WASAPI audio engine (2 => "
-        << params.channels() << ")";
+    // Try the first multi-channel format clamped to 2 (stereo).
     format->nChannels = 2;
   }
   format->nSamplesPerSec = params.sample_rate();
@@ -440,11 +450,17 @@ bool CoreAudioBase::Init() {
     if (!core_audio_utility::IsFormatSupported(
             audio_client.Get(), AUDCLNT_SHAREMODE_SHARED, &format_)) {
       // RingRTC change to try again to match a format for multi-channel.
-      if (IsInput() && (params.channels() > 2)) {
-        RTC_LOG(LS_WARNING) << "Trying again to match for multi-channel";
+      if (params.channels() > 2) {
         format->nChannels = params.channels();
         format->nBlockAlign = (format->wBitsPerSample / 8) * format->nChannels;
         format->nAvgBytesPerSec = format->nSamplesPerSec * format->nBlockAlign;
+
+        // Maintain the channel mask for multi-channel from the mix_format.
+        format_.dwChannelMask = mix_format.dwChannelMask;
+
+        RTC_LOG(LS_WARNING) << "Trying again with: "
+                            << core_audio_utility::WaveFormatToString(&format_);
+
         if (!core_audio_utility::IsFormatSupported(
             audio_client.Get(), AUDCLNT_SHAREMODE_SHARED, &format_)) {
           RTC_LOG(LS_ERROR) << "No multi-channel format matched";
@@ -772,8 +788,8 @@ AudioSessionState CoreAudioBase::GetAudioSessionState() const {
   RTC_DCHECK(audio_session_control_.Get());
   _com_error error = audio_session_control_->GetState(&state);
   if (FAILED(error.Error())) {
-    RTC_DLOG(LS_ERROR) << "IAudioSessionControl::GetState failed: "
-                       << core_audio_utility::ErrorToString(error);
+    RTC_LOG(LS_ERROR) << "IAudioSessionControl::GetState failed: "
+                      << core_audio_utility::ErrorToString(error);
   }
   return state;
 }

--- a/modules/audio_device/win/core_audio_output_win.cc
+++ b/modules/audio_device/win/core_audio_output_win.cc
@@ -118,7 +118,11 @@ int CoreAudioOutput::InitPlayout() {
   WAVEFORMATEX* format = &format_.Format;
   RTC_DCHECK_EQ(format->wFormatTag, WAVE_FORMAT_EXTENSIBLE);
   audio_device_buffer_->SetPlayoutSampleRate(format->nSamplesPerSec);
-  audio_device_buffer_->SetPlayoutChannels(format->nChannels);
+
+  // RingRTC change to ensure that the audio_device_buffer is configured
+  // for a limit of either 1 or 2 channels.
+  audio_device_buffer_->SetPlayoutChannels(
+      std::min((UINT16)2, format->nChannels));
 
   // Create a modified audio buffer class which allows us to ask for any number
   // of samples (and not only multiple of 10ms) to match the optimal
@@ -155,7 +159,7 @@ int CoreAudioOutput::StartPlayout() {
   RTC_DCHECK(fine_audio_buffer_);
   RTC_DCHECK(audio_device_buffer_);
   if (!initialized_) {
-    RTC_DLOG(LS_WARNING)
+    RTC_LOG(LS_WARNING)
         << "Playout can not start since InitPlayout must succeed first";
   }
 
@@ -188,7 +192,7 @@ int CoreAudioOutput::StopPlayout() {
   // Release resources allocated in InitPlayout() and then return if this
   // method is called without any active output audio.
   if (!Playing()) {
-    RTC_DLOG(LS_WARNING) << "No output stream is active";
+    RTC_LOG(LS_WARNING) << "No output stream is active";
     ReleaseCOMObjects();
     initialized_ = false;
     return 0;
@@ -337,8 +341,28 @@ bool CoreAudioOutput::OnDataCallback(uint64_t device_frequency) {
   // `audio_data`. The playout latency is not updated for each callback.
   fine_audio_buffer_->GetPlayoutData(
       rtc::MakeArrayView(reinterpret_cast<int16_t*>(audio_data),
-                         num_requested_frames * format_.Format.nChannels),
+                         num_requested_frames *
+                             // RingRTC change to ensure that only 1 or 2
+                             // channels are read from the buffer.
+                         std::min((UINT16)2, format_.Format.nChannels)),
       latency_ms_);
+
+  // RingRTC change to expand 2 channels to multiple channels.
+  if (format_.Format.nChannels > 2) {
+    UINT32 bytes_per_frame = format_.Format.nChannels * sizeof(int16_t);
+    UINT32 bytes_per_stereo_frame = 2 * sizeof(int16_t);
+
+    // Shift each stereo frame to start on the render frame's stride and
+    // set the remaining channels to zero (silence).
+    int16_t* audio_data_ptr = (int16_t*)audio_data;
+    for (UINT32 i = num_requested_frames - 1; i > 0; --i) {
+      memcpy(&audio_data_ptr[i * format_.Format.nChannels],
+             &audio_data_ptr[i * 2], bytes_per_stereo_frame);
+      memset(&audio_data_ptr[i * format_.Format.nChannels + 2],
+             0, bytes_per_frame - bytes_per_stereo_frame);
+    }
+    memset(&audio_data_ptr[2], 0, bytes_per_frame - bytes_per_stereo_frame);
+  }
 
   // Release the buffer space acquired in IAudioRenderClient::GetBuffer.
   error = audio_render_client_->ReleaseBuffer(num_requested_frames, 0);

--- a/modules/audio_device/win/core_audio_output_win.cc
+++ b/modules/audio_device/win/core_audio_output_win.cc
@@ -356,8 +356,8 @@ bool CoreAudioOutput::OnDataCallback(uint64_t device_frequency) {
     // set the remaining channels to zero (silence).
     int16_t* audio_data_ptr = (int16_t*)audio_data;
     for (UINT32 i = num_requested_frames - 1; i > 0; --i) {
-      memcpy(&audio_data_ptr[i * format_.Format.nChannels],
-             &audio_data_ptr[i * 2], bytes_per_stereo_frame);
+      memmove(&audio_data_ptr[i * format_.Format.nChannels],
+              &audio_data_ptr[i * 2], bytes_per_stereo_frame);
       memset(&audio_data_ptr[i * format_.Format.nChannels + 2],
              0, bytes_per_frame - bytes_per_stereo_frame);
     }

--- a/modules/audio_device/win/core_audio_utility_win.h
+++ b/modules/audio_device/win/core_audio_utility_win.h
@@ -448,13 +448,17 @@ HRESULT GetSharedModeEnginePeriod(IAudioClient3* client3,
 // shared-mode streams. The acquired values should only be utilized for shared
 // mode streamed since there are no preferred settings for an exclusive mode
 // stream.
+// RingRTC change to pass the mix_format for multi-channel.
 HRESULT GetPreferredAudioParameters(IAudioClient* client,
-                                    webrtc::AudioParameters* params);
+                                    webrtc::AudioParameters* params,
+                                    const WAVEFORMATPCMEX* mix_format);
 // As above but override the preferred sample rate and use `sample_rate`
 // instead. Intended mainly for testing purposes and in combination with rate
 // conversion.
+// RingRTC change to pass the mix_format for multi-channel.
 HRESULT GetPreferredAudioParameters(IAudioClient* client,
                                     webrtc::AudioParameters* params,
+                                    const WAVEFORMATPCMEX* mix_format,
                                     uint32_t sample_rate);
 
 // After activating an IAudioClient interface on an audio endpoint device,


### PR DESCRIPTION
This PR is a follow-up to https://github.com/signalapp/webrtc/pull/68 in order to support multi-channel output devices on Windows.

The same approach is used, except in reverse. If the device's preferred format has more than 2 channels, an attempt will be made to see if the default 2 channel audio can be used. If not, a second attempt will be made with the device's preferred number of channels. When data is to be rendered, the audio frames will be converted from 2-channel stereo to N channels, with all channels after the stereo pair being silent.

When trying to initialize with N channels, the Channel Mask has to match what is expected for some devices. This isn't otherwise used in the ADM code though, other than keeping with the assumption that the first two channels are always LEFT and RIGHT. To support this, the mix_format is obtained in the Init() function so that it can be accessed. This would also affect multi-channel input, but testing of that passed successfully.

Some logs were also adjusted. The mix_format will always be logged and the secondary match operations will be logged a little more succinctly. Some other debug logs that were warnings or errors have been changed to always get logged.

Many multi-channel devices prefer the 32-bit floating point sample representation, but the 16-bit linear format that we want has been consistently accepted by WASAPI. According to [this](https://docs.microsoft.com/en-us/windows/win32/coreaudio/device-formats), the audio engine or device driver can do the conversion if necessary.

Finally, it should be noted that some multi-channel devices worked without the conversion. WebRTC was able to handle output devices having 8 channels in one case. However, it is not clear if this is truly supported or not given checks like this:

https://github.com/signalapp/webrtc/blob/e523aa4470ae6af8f1160996999aa4562eb1eb69/audio/audio_transport_impl.cc#L207