### PR TITLE
Support Speech Flag for DTX

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -46,7 +46,7 @@ vars = {
 deps = {
   # RingRTC change to use a fork of opus
   'src/ringrtc/opus/src':
-    'https://github.com/signalapp/opus.git@ab04fbb1b7d0b727636d28fc2cadb5df9febe515',
+    'https://github.com/signalapp/opus.git@74d8597f47aa680c9f9e21ab0b99c8c0632fe27d',
 
   # TODO(kjellander): Move this to be Android-only.
   'src/base':

--- a/modules/audio_coding/codecs/opus/audio_encoder_opus.h
+++ b/modules/audio_coding/codecs/opus/audio_encoder_opus.h
@@ -155,6 +155,9 @@ class AudioEncoderOpusImpl final : public AudioEncoder {
 
   void MaybeUpdateUplinkBandwidth();
 
+  // RingRTC change to detect if an encoded packet contains speech or not
+  bool IsPacketSpeech(int encoded_bytes, const uint8_t* encoded);
+
   AudioEncoderOpusConfig config_;
   const int payload_type_;
   const bool use_stable_target_for_adaptation_;


### PR DESCRIPTION
Now that "Encoded Opus Packets" with multiple encoded frames are being provided by the the opus interface, this PR ensures that the `info.speech` flag is properly updated to reflect whether speech or DTX information is contained in the each packet. The `info.speech` flag is mainly used to control audio level indication in the generated RTP packets.