### PR TITLE
mac: Work around an incorect availability annotation in the 13.3 SDK

### DIFF
--- a/modules/desktop_capture/mac/screen_capturer_mac.mm
+++ b/modules/desktop_capture/mac/screen_capturer_mac.mm
@@ -20,6 +20,87 @@
 #include "rtc_base/trace_event.h"
 #include "sdk/objc/helpers/scoped_cftyperef.h"
 
+// All these symbols have incorrect availability annotations in the 13.3 SDK.
+// These have the correct annotation. See https://crbug.com/1431897.
+// TODO(thakis): Remove this once FB12109479 is fixed and we updated to an SDK
+// with the fix.
+
+static CGDisplayStreamRef __nullable
+    wrapCGDisplayStreamCreate(CGDirectDisplayID display,
+                              size_t outputWidth,
+                              size_t outputHeight,
+                              int32_t pixelFormat,
+                              CFDictionaryRef __nullable properties,
+                              CGDisplayStreamFrameAvailableHandler __nullable handler)
+        CG_AVAILABLE_BUT_DEPRECATED(
+            10.8,
+            14.0,
+            "Please use ScreenCaptureKit API's initWithFilter:configuration:delegate: instead") {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunguarded-availability-new"
+  return CGDisplayStreamCreate(
+      display, outputWidth, outputHeight, pixelFormat, properties, handler);
+#pragma clang diagnostic pop
+}
+
+static CFRunLoopSourceRef __nullable
+    wrapCGDisplayStreamGetRunLoopSource(CGDisplayStreamRef cg_nullable displayStream)
+        CG_AVAILABLE_BUT_DEPRECATED(10.8,
+                                    14.0,
+                                    "There is no direct replacement for this function. Please use "
+                                    "ScreenCaptureKit API's SCStream to replace CGDisplayStream") {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunguarded-availability-new"
+  return CGDisplayStreamGetRunLoopSource(displayStream);
+#pragma clang diagnostic pop
+}
+
+static CGError wrapCGDisplayStreamStart(CGDisplayStreamRef cg_nullable displayStream)
+    CG_AVAILABLE_BUT_DEPRECATED(10.8,
+                                14.0,
+                                "Please use ScreenCaptureKit API's "
+                                "startCaptureWithCompletionHandler: to start a stream instead") {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunguarded-availability-new"
+  return CGDisplayStreamStart(displayStream);
+#pragma clang diagnostic pop
+}
+
+static CGError wrapCGDisplayStreamStop(CGDisplayStreamRef cg_nullable displayStream)
+    CG_AVAILABLE_BUT_DEPRECATED(10.8,
+                                14.0,
+                                "Please use ScreenCaptureKit API's "
+                                "stopCaptureWithCompletionHandler: to stop a stream instead") {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunguarded-availability-new"
+  return CGDisplayStreamStop(displayStream);
+#pragma clang diagnostic pop
+}
+
+static CFStringRef wrapkCGDisplayStreamShowCursor() CG_AVAILABLE_BUT_DEPRECATED(
+    10.8,
+    14.0,
+    "Please use ScreenCaptureKit API's SCStreamConfiguration showsCursor property instead") {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunguarded-availability-new"
+  return kCGDisplayStreamShowCursor;
+#pragma clang diagnostic pop
+}
+
+static const CGRect* __nullable
+    wrapCGDisplayStreamUpdateGetRects(CGDisplayStreamUpdateRef __nullable updateRef,
+                                      CGDisplayStreamUpdateRectType rectType,
+                                      size_t* rectCount)
+        CG_AVAILABLE_BUT_DEPRECATED(10.8,
+                                    14.0,
+                                    "Please use ScreenCaptureKit API's SCStreamFrameInfo with "
+                                    "SCStreamFrameInfoContentRect instead") {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunguarded-availability-new"
+  return CGDisplayStreamUpdateGetRects(updateRef, rectType, rectCount);
+#pragma clang diagnostic pop
+}
+
 namespace webrtc {
 
 namespace {
@@ -459,7 +540,7 @@ bool ScreenCapturerMac::RegisterRefreshAndMoveHandlers() {
 
       size_t count = 0;
       const CGRect* rects =
-          CGDisplayStreamUpdateGetRects(updateRef, kCGDisplayStreamUpdateDirtyRects, &count);
+          wrapCGDisplayStreamUpdateGetRects(updateRef, kCGDisplayStreamUpdateDirtyRects, &count);
       if (count != 0) {
         // According to CGDisplayStream.h, it's safe to call
         // CGDisplayStreamStop() from within the callback.
@@ -469,20 +550,20 @@ bool ScreenCapturerMac::RegisterRefreshAndMoveHandlers() {
 
     rtc::ScopedCFTypeRef<CFDictionaryRef> properties_dict(
         CFDictionaryCreate(kCFAllocatorDefault,
-                           (const void* []){kCGDisplayStreamShowCursor},
-                           (const void* []){kCFBooleanFalse},
+                           (const void*[]){wrapkCGDisplayStreamShowCursor()},
+                           (const void*[]){kCFBooleanFalse},
                            1,
                            &kCFTypeDictionaryKeyCallBacks,
                            &kCFTypeDictionaryValueCallBacks));
 
-    CGDisplayStreamRef display_stream = CGDisplayStreamCreate(
+    CGDisplayStreamRef display_stream = wrapCGDisplayStreamCreate(
         display_id, pixel_width, pixel_height, 'BGRA', properties_dict.get(), handler);
 
     if (display_stream) {
-      CGError error = CGDisplayStreamStart(display_stream);
+      CGError error = wrapCGDisplayStreamStart(display_stream);
       if (error != kCGErrorSuccess) return false;
 
-      CFRunLoopSourceRef source = CGDisplayStreamGetRunLoopSource(display_stream);
+      CFRunLoopSourceRef source = wrapCGDisplayStreamGetRunLoopSource(display_stream);
       CFRunLoopAddSource(CFRunLoopGetCurrent(), source, kCFRunLoopCommonModes);
       display_streams_.push_back(display_stream);
     }
@@ -495,9 +576,9 @@ void ScreenCapturerMac::UnregisterRefreshAndMoveHandlers() {
   RTC_DCHECK(thread_checker_.IsCurrent());
 
   for (CGDisplayStreamRef stream : display_streams_) {
-    CFRunLoopSourceRef source = CGDisplayStreamGetRunLoopSource(stream);
+    CFRunLoopSourceRef source = wrapCGDisplayStreamGetRunLoopSource(stream);
     CFRunLoopRemoveSource(CFRunLoopGetCurrent(), source, kCFRunLoopCommonModes);
-    CGDisplayStreamStop(stream);
+    wrapCGDisplayStreamStop(stream);
     CFRelease(stream);
   }
   display_streams_.clear();


### PR DESCRIPTION
Cherry picking this to allow for building for mac with Xcode 14.3.