### PR TITLE
build_ios_libs.py: Allow customizing the deployment target

### DIFF
--- a/tools_webrtc/ios/build_ios_libs.py
+++ b/tools_webrtc/ios/build_ios_libs.py
@@ -39,10 +39,9 @@ ENABLED_ARCHS = [
 DEFAULT_ARCHS = [
     'device:arm64', 'simulator:arm64', 'simulator:x64'
 ]
-IOS_DEPLOYMENT_TARGET = {
-    # RingRTC change to control iOS targets
-    'device': '11.0',
-    'simulator': '11.0',
+IOS_MINIMUM_DEPLOYMENT_TARGET = {
+    'device': '12.0',
+    'simulator': '12.0',
     'catalyst': '14.0'
 }
 LIBVPX_BUILD_VP9 = False
@@ -100,6 +99,12 @@ def _ParseArgs():
                       action='store_true',
                       default=False,
                       help='Use RBE to build.')
+  # RingRTC change to control iOS targets
+  parser.add_argument('--deployment-target',
+                      default=IOS_MINIMUM_DEPLOYMENT_TARGET['device'],
+                      help='Raise the minimum deployment target to build for. '
+                      'Cannot be lowered below 12.0 for iOS/iPadOS '
+                      'and 14.0 for Catalyst')
   parser.add_argument(
       '--extra-gn-args',
       default=[],
@@ -150,6 +155,12 @@ def _ParseArchitecture(architectures):
       archs.add(target_cpu)
 
   return result
+
+
+def _VersionMax(a, b):
+  return max(a, b, key=lambda version: [
+      int(component) for component in version.split('.')
+  ])
 
 
 def BuildWebRTC(output_dir, target_environment, target_arch, flavor,
@@ -235,6 +246,9 @@ def main():
   framework_paths = []
   all_lib_paths = []
   for (environment, archs) in list(architectures.items()):
+    ios_deployment_target = _VersionMax(
+        args.deployment_target,
+        IOS_MINIMUM_DEPLOYMENT_TARGET[environment])
     framework_path = os.path.join(args.output_dir, environment)
     framework_paths.append(framework_path)
     lib_paths = []
@@ -242,8 +256,8 @@ def main():
       lib_path = os.path.join(framework_path, arch + '_libs')
       lib_paths.append(lib_path)
       BuildWebRTC(lib_path, environment, arch, args.build_config,
-                  gn_target_name, IOS_DEPLOYMENT_TARGET[environment],
-                  LIBVPX_BUILD_VP9, args.use_goma, args.use_remoteexec, gn_args)
+                  gn_target_name, ios_deployment_target, LIBVPX_BUILD_VP9,
+                  args.use_goma, args.use_remoteexec, gn_args)
     all_lib_paths.extend(lib_paths)
 
     # Combine the slices.


### PR DESCRIPTION
Previously, this script hardcoded deployment targets for device, simulator, and Catalyst builds. This commit turns those into minimums (and restores them to match WebRTC's tested minimum of iOS 12), but allows callers to pass a higher version with `--deployment-target`.