### PR TITLE
Use the built-in video factories

### DIFF
--- a/ringrtc/rffi/BUILD.gn
+++ b/ringrtc/rffi/BUILD.gn
@@ -88,8 +88,12 @@ if (is_linux || is_mac || is_win) {
 
     configs += [ ":ringrtc_rffi_config" ]
 
+    allow_poison = [ "software_video_codecs" ]
+
     deps = [
       "//sdk:media_constraints",
+      "//api/video_codecs:builtin_video_decoder_factory",
+      "//api/video_codecs:builtin_video_encoder_factory",
     ]
   }
 }

--- a/ringrtc/rffi/src/peer_connection.cc
+++ b/ringrtc/rffi/src/peer_connection.cc
@@ -323,9 +323,7 @@ Rust_sessionDescriptionFromV4(bool offer,
     if (rffi_codec.type == kRffiVideoCodecVp9) {
       if (enable_vp9) {
         auto vp9 = cricket::CreateVideoCodec(VP9_PT, cricket::kVp9CodecName);
-        vp9.params[kVP9FmtpProfileId] = VP9ProfileToString(VP9Profile::kProfile0);
         auto vp9_rtx = cricket::CreateVideoRtxCodec(VP9_RTX_PT, VP9_PT);
-        vp9_rtx.params[kVP9FmtpProfileId] = VP9ProfileToString(VP9Profile::kProfile0);
         add_video_feedback_params(&vp9);
 
         video->AddCodec(vp9);

--- a/ringrtc/rffi/src/peer_connection_factory.cc
+++ b/ringrtc/rffi/src/peer_connection_factory.cc
@@ -9,12 +9,8 @@
 #include "api/rtc_event_log/rtc_event_log_factory.h"
 #include "api/audio_codecs/builtin_audio_decoder_factory.h"
 #include "api/audio_codecs/builtin_audio_encoder_factory.h"
-#include "api/video_codecs/video_decoder_factory_template.h"
-#include "api/video_codecs/video_decoder_factory_template_libvpx_vp8_adapter.h"
-#include "api/video_codecs/video_decoder_factory_template_libvpx_vp9_adapter.h"
-#include "api/video_codecs/video_encoder_factory_template.h"
-#include "api/video_codecs/video_encoder_factory_template_libvpx_vp8_adapter.h"
-#include "api/video_codecs/video_encoder_factory_template_libvpx_vp9_adapter.h"
+#include "api/video_codecs/builtin_video_decoder_factory.h"
+#include "api/video_codecs/builtin_video_encoder_factory.h"
 #include "media/engine/webrtc_media_engine.h"
 #include "modules/audio_mixer/audio_mixer_impl.h"
 #include "modules/audio_device/dummy/file_audio_device_factory.h"
@@ -128,12 +124,8 @@ class PeerConnectionFactoryWithOwnedThreads
       .Create();
 
     media_dependencies.audio_mixer = AudioMixerImpl::Create();
-    media_dependencies.video_encoder_factory =
-        std::make_unique<VideoEncoderFactoryTemplate<
-            LibvpxVp8EncoderTemplateAdapter, LibvpxVp9EncoderTemplateAdapter>>();
-    media_dependencies.video_decoder_factory =
-        std::make_unique<VideoDecoderFactoryTemplate<
-            LibvpxVp8DecoderTemplateAdapter, LibvpxVp9DecoderTemplateAdapter>>();
+    media_dependencies.video_encoder_factory = CreateBuiltinVideoEncoderFactory();
+    media_dependencies.video_decoder_factory = CreateBuiltinVideoDecoderFactory();
     dependencies.media_engine = cricket::CreateMediaEngine(std::move(media_dependencies));
 
     auto factory = CreateModularPeerConnectionFactory(std::move(dependencies));


### PR DESCRIPTION
- The `BuiltinVideoEncoderFactory` wraps the `SimulcastEncoderAdapter` on the [encoder](https://github.com/signalapp/webrtc/blob/main/api/video_codecs/builtin_video_encoder_factory.cc#L45) which is required for VP8 simulcast to work in Group Calls.
- The `BuiltInVideoDecoderFactory` uses the `InternalDecoderFactory` which specifies [supported formats](https://github.com/signalapp/webrtc/blob/main/media/engine/internal_decoder_factory.cc#L47) like VP9 Profile 0 used by RingRTC.