### PR TITLE
roll libvpx to include fix for CVE-2023-5217

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -297,7 +297,7 @@ deps = {
   'src/third_party/perfetto':
     'https://android.googlesource.com/platform/external/perfetto.git@0ba4c2cd12264c4d33787fb700b93c67ee9fbc11',
   'src/third_party/libvpx/source/libvpx':
-    'https://chromium.googlesource.com/webm/libvpx.git@2245df50a6d360d33fccd51479c48f2210ed607a',
+    'https://chromium.googlesource.com/webm/libvpx.git@3fbd1dca6a4d2dad332a2110d646e4ffef36d590',
   'src/third_party/libyuv':
     'https://chromium.googlesource.com/libyuv/libyuv.git@552571e8b24b2619c39ec176e6cb8e75d3e7fdd3',
   'src/third_party/lss': {


### PR DESCRIPTION
this rolls in the backported CL: https://chromium-review.googlesource.com/c/webm/libvpx/+/4894795

vuln described so far just here: https://chromereleases.googleblog.com/2023/09/stable-channel-update-for-desktop_27.html
>[$NA][[1486441](https://crbug.com/1486441)] High CVE-2023-5217: Heap buffer overflow in vp8 encoding in libvpx. Reported by Clément Lecigne of Google's Threat Analysis Group on 2023-09-25

https://nvd.nist.gov/vuln/detail/CVE-2023-5217